### PR TITLE
Support multiple types in JSON Schema

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "bear/resource": "^1.7",
-        "twig/twig": "^1.0|^2.4"
+        "twig/twig": "^1.7|^2.4"
     },
     "require-dev": {
         "bear/aura-router-module": "^1.2"

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -301,7 +301,11 @@ namespace BEAR\ApiDoc {
     {% for prop_name, prop in schema.properties %}
         <tr>
             <td>{{ prop_name }}</td>
+            {% if prop.type is iterable %}
+            <td>{{ prop.type | join(\', \') }}</td>
+            {% else %}
             <td>{{ prop.type }}</td>
+            {% endif %}
             <td>{{ prop.description }}</td>
             <td>
                 <table class="table table-condensed">


### PR DESCRIPTION
## 事象と概要

JSON Schema の type に配列を定義すると下記のエラーが出ます。

```
PHP Notice:  Array to string conversion in /path/to/vendor/twig/twig/lib/Twig/Environment.php(378) : eval()'d code on line 41
```

また、画面は下記のように表示されます。
![screenshot-127 0 0 1-8083-2017-10-25-14-29-02-887 1](https://user-images.githubusercontent.com/434940/31982171-44e4dda0-b992-11e7-8729-cbdd81a19cfb.png)

最新の仕様ですと

> The value of this keyword MUST be either a string or an array. If it is an array, elements of the array MUST be strings and MUST be unique.
>
> http://json-schema.org/latest/json-schema-validation.html#rfc.section.6.25

とありますし、 BEAR.Sundayが依存している justinrainbow/json-schema でも
下記にありますように、この形式をサポートしているようなので

See: https://github.com/justinrainbow/json-schema/blob/master/tests/Constraints/UnionTypesTest.php

ApiDoc でもサポートしていただければ幸いです。

## 変更後の画面

![screenshot-127 0 0 1-8083-2017-10-25-14-20-02-935 1](https://user-images.githubusercontent.com/434940/31982175-4cc2d536-b992-11e7-8196-379bf2fba650.png)

## 確認に使ったソースコード

`User.php`
```php
<?php
namespace Kalibora\BearSample\Resource\App;

use BEAR\Resource\ResourceObject;
use BEAR\Resource\Annotation\JsonSchema;

class User extends ResourceObject
{
    /**
     * @JsonSchema(schema="user.json")
     */
    public function onGet()
    {
        $this->body = [
            'firstName' => 'mucha',
            'lastName' => 'alfons',
            'age' => null
        ];

        return $this;
    }
}
```

`user.json`
```json
{
    "type": "object",
    "properties": {
        "firstName": {
            "type": "string",
            "maxLength": 30,
            "pattern": "[a-z\\d~+-]+"
        },
        "lastName": {
            "type": "string",
            "maxLength": 30,
            "pattern": "[a-z\\d~+-]+"
        },
        "age": {
            "type": ["integer", "null"]
        }
    },
    "required": ["firstName", "lastName", "age"]
}
```
