### PR TITLE
Markdown API document

### DIFF
--- a/bin/bear.apidoc
+++ b/bin/bear.apidoc
@@ -5,7 +5,9 @@
  *
  * Usage: bear.apidoc \'MyVendor\MyProject\' prod-html-app /path/to/project
  */
-use BEAR\ApiDoc\DocGen;use BEAR\AppMeta\Exception\AppNameException;
+use BEAR\ApiDoc\DocGen;
+use BEAR\ApiDoc\MarkdownTemplate;
+use BEAR\AppMeta\Exception\AppNameException;
 
 if ($argc !== 4 && $argc !== 5 ) {
     echo 'usage: bear.apidoc <MyVendor\MyProject> </path/to/app_dir> <path/to/doc_dir> [context]' . PHP_EOL;
@@ -26,7 +28,7 @@ if (! file_exists($docDir) || ! is_writable($docDir)) {
 require $autoload;
 
 try {
-    echo (new DocGen)($appName, realpath($docDir), $context);
+    echo (new DocGen)($appName, realpath($docDir), $context, MarkdownTemplate::class);
     exit(0);
 } catch (AppNameException $e) {
     throw new InvalidArgumentException(sprintf('[%s]: invalid application name (ex. "Vendor\Project"', $e->getMessage()));

--- a/src/AbstractTemplate.php
+++ b/src/AbstractTemplate.php
@@ -76,7 +76,7 @@ abstract class AbstractTemplate
 <p><b>Link Relations</b></p>
 <ul>
     {% for rel in rels %}
-        <li><a href="../docs/rels/{{ rel }}.html">{{ rel }}</a>
+        <li><a href="../docs/rels/{{ rel }}.{{ ext }}">{{ rel }}</a>
     {% endfor %}
 </ul>
 <p><b>URIs</b></p>

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -74,7 +74,7 @@ class ApiDoc extends ResourceObject
     public function __construct(
         ResourceInterface $resource,
         string $schemaDir,
-        Template $template,
+        AbstractTemplate $template,
         $routerContainer,
         string $routerFile = null
     ) {

--- a/src/DocGen.php
+++ b/src/DocGen.php
@@ -22,10 +22,11 @@ final class DocGen
         $meta = new Meta($appName, $context);
         $injector = new AppInjector($appName, $context, $meta);
         $injector->clear();
+        $responderModule = new FileResponderModule($docDir, $templateClass);
         /** @var ApiDoc $apiDoc */
-        $apiDoc = $injector->getOverrideInstance(new ApiDocModule, ApiDoc::class);
+        $apiDoc = $injector->getOverrideInstance(new ApiDocModule($responderModule), ApiDoc::class);
         /** @var FileResponder $responder */
-        $responder = $injector->getOverrideInstance(new FileResponderModule($docDir, $templateClass), FileResponder::class);
+        $responder = $injector->getOverrideInstance($responderModule, FileResponder::class);
         // set twig renderer by self
         $apiDoc->setRenderer(new NullRenderer);
         $apiDoc->transfer($responder, []);

--- a/src/FileResponder.php
+++ b/src/FileResponder.php
@@ -102,7 +102,11 @@ final class FileResponder implements TransferInterface
         if (! is_dir($docDir) && ! mkdir($docDir, 0777, true) && ! is_dir($docDir)) {
             throw new \RuntimeException(sprintf('Directory "%s" was not created', $docDir)); // @codeCoverageIgnore
         }
-        $apiDoc->body = $index + ['rels' => $rels, 'page' => 'index'];
+        $apiDoc->body = $index + [
+            'rels' => $rels,
+            'page' => 'index',
+            'ext' => $this->ext
+        ];
         $apiDoc->view = null;
         $view = (string) $apiDoc;
         file_put_contents($docDir . '/index.' . $this->ext, $view);
@@ -112,7 +116,10 @@ final class FileResponder implements TransferInterface
     {
         foreach ($uris as $uri) {
             $uriDir = $docDir . '/uri';
-            $apiDoc->body = (array) $uri + ['page' => 'uri'];
+            $apiDoc->body = (array) $uri + [
+                'page' => 'uri',
+                'ext' => $this->ext
+            ];
             $apiDoc->view = null;
             $view = (string) $apiDoc;
             if (! is_dir($uriDir) && ! mkdir($uriDir, 0777, true) && ! is_dir($uriDir)) {
@@ -144,7 +151,11 @@ final class FileResponder implements TransferInterface
             ];
             ($this->jsonSaver)($docDir . '/rels', $rel, (object) $json);
             // write HTML
-            $apiDoc->body = $targetLink + ['page' => 'rel'] + ['relMeta' => $relMeta];
+            $apiDoc->body = $targetLink + [
+                'page' => 'rel',
+                'relMeta' => $relMeta,
+                'ext' => $this->ext
+            ];
             $apiDoc->view = null;
             $view = (string) $apiDoc;
             file_put_contents(sprintf('%s/rels/%s.%s', $docDir, $relMeta['rel'], $this->ext), $view);

--- a/src/FileResponder.php
+++ b/src/FileResponder.php
@@ -60,11 +60,12 @@ final class FileResponder implements TransferInterface
     /**
      * @Named("docDir=api_doc_dir,host=json_schema_host")
      */
-    public function __construct(string $docDir, string $host = '')
+    public function __construct(string $docDir, string $host, AbstractTemplate $template)
     {
         $this->docDir = $docDir;
         $this->host = $host;
         $this->jsonSaver = new JsonSaver;
+        $this->ext = $template->ext;
     }
 
     /**
@@ -104,7 +105,7 @@ final class FileResponder implements TransferInterface
         $apiDoc->body = $index + ['rels' => $rels, 'page' => 'index'];
         $apiDoc->view = null;
         $view = (string) $apiDoc;
-        file_put_contents($docDir . '/index.html', $view);
+        file_put_contents($docDir . '/index.' . $this->ext, $view);
     }
 
     private function writeUris(ApiDoc $apiDoc, array $uris, string $docDir)
@@ -117,7 +118,8 @@ final class FileResponder implements TransferInterface
             if (! is_dir($uriDir) && ! mkdir($uriDir, 0777, true) && ! is_dir($uriDir)) {
                 throw new \RuntimeException(sprintf('Directory "%s" was not created', $uriDir)); // @codeCoverageIgnore
             }
-            file_put_contents(sprintf('%s/%s', $docDir, $uri->filePath), $view);
+            $file = sprintf('%s/uri%s.%s', $docDir, $uri->uriPath, $this->ext);
+            file_put_contents($file, $view);
         }
     }
 
@@ -145,7 +147,7 @@ final class FileResponder implements TransferInterface
             $apiDoc->body = $targetLink + ['page' => 'rel'] + ['relMeta' => $relMeta];
             $apiDoc->view = null;
             $view = (string) $apiDoc;
-            file_put_contents(sprintf('%s/rels/%s.html', $docDir, $relMeta['rel']), $view);
+            file_put_contents(sprintf('%s/rels/%s.%s', $docDir, $relMeta['rel'], $this->ext), $view);
             $rels[] = $rel;
         }
 

--- a/src/MarkdownTemplate.php
+++ b/src/MarkdownTemplate.php
@@ -1,0 +1,128 @@
+<?php
+namespace BEAR\ApiDoc;
+
+final class MarkdownTemplate extends AbstractTemplate
+{
+    /**
+     * Root Page
+     */
+    public $index =  /* @lang Markdown */ <<< 'EOT'
+{% if page == "index" %}# API Doc
+{% include 'home.html.twig' %}
+{% elseif page == "uri" %}
+{% include 'uri.html.twig' %}
+{% elseif page == "rel" %}
+{% include 'rel.html.twig' %}
+{% else %}
+    Unknown page runtime exception !
+{% endif %}
+EOT;
+
+    /**
+     * Home page content
+     */
+    public $home =  /* @lang Markdown */'
+{% for title, message in messages %}
+* **{{ title|capitalize }}** {{ message|linkify|raw|nl2br }}
+{% endfor %}
+
+## Link Relations
+
+{% for rel in rels %}
+* [{{ rel }}](rels/{{ rel }}.html)
+{% endfor %}
+
+## URIs
+
+{% for path, uri in uris %}
+* [{{ path }}]({{ uri.filePath }})
+{% endfor %}
+
+## Json Schemas
+
+{% for schema in schemas %}
+* [{{  schema.id }}]({{ schema.docHref }}) - {{ schema.title }}
+{% endfor %}
+';
+
+    /**
+     * Link Relation Page
+     */
+    public $rel = /* @lang Markdown */ <<< 'EOT'
+# {{ relMeta.rel }} (relation)
+
+{{ summary }}
+
+## {{ relMeta.method|upper }}
+
+[{{ relMeta.href }}](uri{{ relMeta.href }}.html)
+{% include 'request.html.twig' %}
+EOT;
+
+    /**
+     * URI based API page
+     */
+    public $uri = /* @lang Markdown */ <<< 'EOT'
+# {{ uriPath }}
+{% for method_name, method in doc %}
+## {{ method_name }}
+
+{{ method.summary }}
+
+### Request
+    {% set request = method.request %}
+    {% include 'request.html.twig' %}
+
+{% if method.schema %}
+### Response
+    {%  endif %}
+
+    {%  set meta = method.meta%}
+    {%  set schema = method.schema%}
+    {%  include 'schema.html.twig' %}
+    {%  include 'link.html.twig' %}
+    {%  include 'definition.html.twig' %}
+{% endfor %}
+EOT;
+
+    public $definition =  /* @lang Markdown */ <<< 'EOT'
+{% for definition_name, definition in schema.definitions %}
+    {% if loop.first %}
+#### Definitions
+    {% endif %}
+    {%  set schema = definition %}
+    {%  include \'schema.html.twig\' %}
+{% endfor %}
+EOT;
+
+    public $links =  /* @lang Markdown */ <<< 'EOT'
+{% for link in method.links %}
+    {% if loop.first %}
+#### Link
+| Rel  | Href  | Method | Title | 
+    {% endif %}
+| {{ link.rel }} | {{ link.href }} | {{ link.method|upper }} | {{ link.title }} |
+{% endfor %}';
+EOT;
+
+    public $allow = '';
+
+    /**
+     * Request parameter table
+     */
+    public $request = /* @lang Markdown */
+        <<< 'EOT'
+{% for param_name, parameters in request.parameters %}
+{% if loop.first %}
+
+| Name  | Type  | Description | Default | Required | 
+|-------|-------|-------------|---------|----------|          
+{% endif %}
+| {{ param_name }} | {{ parameters.type }} | {{ parameters.description }} | {{ parameters.default }} | {% if param_name in method.request.required %}Required{% else %}Optional{% endif %}
+{% else %}
+   No parameters required.
+{% endfor %}
+EOT;
+    public $shcemaTable = '';
+    public $ext = 'md';
+}

--- a/src/MarkdownTemplate.php
+++ b/src/MarkdownTemplate.php
@@ -29,7 +29,7 @@ EOT;
 ## Link Relations
 
 {% for rel in rels %}
-* [{{ rel }}](rels/{{ rel }}.html)
+* [{{ rel }}](rels/{{ rel }}.{{ ext }})
 {% endfor %}
 
 ## URIs
@@ -38,7 +38,7 @@ EOT;
 * [{{ path }}]({{ uri.filePath }})
 {% endfor %}
 
-## Json Schemas
+## Schemas
 
 {% for schema in schemas %}
 * [{{  schema.id }}]({{ schema.docHref }}) - {{ schema.title }}
@@ -55,7 +55,7 @@ EOT;
 
 ## {{ relMeta.method|upper }}
 
-[{{ relMeta.href }}](uri{{ relMeta.href }}.html)
+[{{ relMeta.href }}](../uri/{{ relMeta.href }}.{{ ext }})
 {% include 'request.html.twig' %}
 EOT;
 
@@ -73,36 +73,30 @@ EOT;
     {% set request = method.request %}
     {% include 'request.html.twig' %}
 
-{% if method.schema %}
-### Response
-    {%  endif %}
 
-    {%  set meta = method.meta%}
-    {%  set schema = method.schema%}
-    {%  include 'schema.html.twig' %}
-    {%  include 'link.html.twig' %}
-    {%  include 'definition.html.twig' %}
+### Response
+
+{%  set meta = method.meta %}
+{%  set schema = method.schema %}
+
+{%  include 'schema.html.twig' %}
+{%  include 'link.html.twig' %}
 {% endfor %}
 EOT;
 
     public $definition =  /* @lang Markdown */ <<< 'EOT'
 {% for definition_name, definition in schema.definitions %}
     {% if loop.first %}
-#### Definitions
-    {% endif %}
-    {%  set schema = definition %}
-    {%  include \'schema.html.twig\' %}
-{% endfor %}
 EOT;
 
     public $links =  /* @lang Markdown */ <<< 'EOT'
 {% for link in method.links %}
-    {% if loop.first %}
-#### Link
-| Rel  | Href  | Method | Title | 
-    {% endif %}
-| {{ link.rel }} | {{ link.href }} | {{ link.method|upper }} | {{ link.title }} |
-{% endfor %}';
+{% if loop.first %}
+
+### Link
+{% endif %}
+ * [{{ link.rel }}](../rels/{{ link.rel }}.{{ ext }})
+{% endfor %}
 EOT;
 
     public $allow = '';
@@ -110,8 +104,7 @@ EOT;
     /**
      * Request parameter table
      */
-    public $request = /* @lang Markdown */
-        <<< 'EOT'
+    public $request = /* @lang Markdown */ <<< 'EOT'
 {% for param_name, parameters in request.parameters %}
 {% if loop.first %}
 
@@ -120,9 +113,39 @@ EOT;
 {% endif %}
 | {{ param_name }} | {{ parameters.type }} | {{ parameters.description }} | {{ parameters.default }} | {% if param_name in method.request.required %}Required{% else %}Optional{% endif %}
 {% else %}
-   No parameters required.
+
+(No parameters required.)
 {% endfor %}
 EOT;
-    public $shcemaTable = '';
+
+    /**
+     * Schema table
+     */
+    public $shcemaTable = /* @lang Markdown */ <<< 'EOT'
+{% if schema.properties %}
+| Name  | Type  | Description | Default | Required | 
+|-------|-------|-------------|---------|----------| 
+{% for prop_name, prop in schema.properties %}
+| {{ prop_name }} | {{ prop.type }} | {{ prop.description }} |  {{ prop.default }} | {% if prop_name in schema.required %} Required {% else %} Optional {% endif %} | 
+{% endfor %}
+[{{ meta.id }}](../{{ meta.docHref }})
+{% endif %}
+
+{% if schema.type == 'array' %}
+    {% for key, item in schema.items %}
+* ** Array ** 
+            {% if key == '$ref' %}
+                <td>{{ item }}<a href="../schema/{{ item  }}"><i class="fas fa-cloud-download-alt"></i></a></td>
+            {% else %}
+                <td>{{ item | json_encode(constant('JSON_PRETTY_PRINT') b-or constant('JSON_UNESCAPED_SLASHES')) }}</td>
+            {% endif %}
+    {% endfor %}
+{% endif %}
+
+{% if schema.type is defined %}
+* **Type** {{ schema.type }}</span>
+{% endif %}
+EOT;
+
     public $ext = 'md';
 }


### PR DESCRIPTION
This PR enables to save API document in Markdown format instead of HTML.

We can use normal GH site for API document site. It's easier to have a private API document when GH enterprise is not an option. Easier template modification.
