### PR TITLE
Prettify schema constraints

### DIFF
--- a/src/SchemaConstraints.php
+++ b/src/SchemaConstraints.php
@@ -13,8 +13,10 @@ use function in_array;
 use function is_string;
 use function json_encode;
 use function sprintf;
+use function str_replace;
 
 use const FILTER_VALIDATE_URL;
+use const JSON_PRETTY_PRINT;
 use const JSON_UNESCAPED_SLASHES;
 
 /**
@@ -65,6 +67,12 @@ final class SchemaConstraints
 
     public function __toString(): string
     {
-        return $this->constrains === [] ? '' : (string) json_encode($this->constrains, JSON_UNESCAPED_SLASHES);
+        return $this->constrains === []
+            ? ''
+            : str_replace(
+                ["\n", ' '],
+                ['<br>', '&nbsp;'],
+                (string) json_encode($this->constrains, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+            );
     }
 }

--- a/tests/DocMethodTest.php
+++ b/tests/DocMethodTest.php
@@ -68,9 +68,9 @@ class DocMethodTest extends TestCase
 
 | Name  | Type  | Description | Required | Constraint | Example |
 |-------|-------|-------------|----------|------------|---------| 
-| fruits | array |  | Optional | {"items":{"type":"string"}} |  |
-| vegetables | array |  | Optional | {"items":{"\$ref":"#/definitions/veggie"}} |  |
-| juice | object |  | Optional | {"\$ref":"#/definitions/juice"} |  |
+| fruits | array |  | Optional | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"items":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"type":&nbsp;"string"<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>} |  |
+| vegetables | array |  | Optional | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"items":&nbsp;{<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"\$ref":&nbsp;"#/definitions/veggie"<br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>} |  |
+| juice | object |  | Optional | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"\$ref":&nbsp;"#/definitions/juice"<br>} |  |
 EOT;
 
         $result = (string) $docMethod;

--- a/tests/SchemaPropTest.php
+++ b/tests/SchemaPropTest.php
@@ -30,7 +30,7 @@ class SchemaPropTest extends TestCase
 
     public function testToString(): void
     {
-        $expected = '| name | type | desc | Optional | {"minimum":0} |  |';
+        $expected = '| name | type | desc | Optional | {<br>&nbsp;&nbsp;&nbsp;&nbsp;"minimum":&nbsp;0<br>} |  |';
         $this->assertSame($expected, (string) $this->prop);
     }
 }


### PR DESCRIPTION
JSON Schemaから生成される `Constraints` をpretty printするのはどうでしょうか？

* Before
<img width="1100" alt="image" src="https://user-images.githubusercontent.com/892913/158093278-1e8b3b27-481a-47d4-ba8e-06682aed3854.png">

* After
<img width="980" alt="image" src="https://user-images.githubusercontent.com/892913/158093436-56a83261-3d84-4e54-9a95-bbeadb92cdc3.png">

