### PR TITLE
Allow rize/uri-template v0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "bear/app-meta": "^1.7",
         "doctrine/annotations": "^1.12 || ^2.0",
         "ray/di": "^2.16",
-        "rize/uri-template": "^0.3.3",
+        "rize/uri-template": "^0.3.3 || ^0.4",
         "bear/package": "^1.9",
         "koriym/app-state-diagram": "^0.11 ",
         "michelf/php-markdown": "^1.9.1 || ^2.0",

--- a/src/Src.php
+++ b/src/Src.php
@@ -6,7 +6,6 @@ namespace BEAR\ApiDoc;
 
 use Rize\UriTemplate;
 use Rize\UriTemplate\Node\Literal;
-use Rize\UriTemplate\Parser;
 use Stringable;
 
 use function assert;
@@ -33,7 +32,6 @@ final class Src implements Stringable
     {
         $uriTemplate = new UriTemplate($this->src);
         $parser = $uriTemplate->getParser();
-        assert($parser instanceof Parser);
         $urls = $parser->parse($this->src);
         $literal = $urls[0];
         assert($literal instanceof Literal);


### PR DESCRIPTION
BEAR.Resource is only supported ^0.4 from 1.24.0

https://github.com/bearsunday/BEAR.Resource/compare/1.23.0...1.24.0

## Summary by Sourcery

Build:
- Allow the use of `rize/uri-template` v0.4 in addition to v0.3.3.