### PR TITLE
Add #[Alps] attribute for mapping REST to ALPS semantic descriptors

### DIFF
--- a/src/Annotation/Alps.php
+++ b/src/Annotation/Alps.php
@@ -14,7 +14,7 @@ use Attribute;
  *
  * @see https://alps-io.github.io/spec/
  */
-#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 final class Alps
 {
     public function __construct(

--- a/src/Annotation/Alps.php
+++ b/src/Annotation/Alps.php
@@ -6,6 +6,8 @@ namespace BEAR\ApiDoc\Annotation;
 
 use Attribute;
 
+use function assert;
+
 /**
  * Maps REST resource/method to ALPS semantic descriptor
  *
@@ -21,5 +23,6 @@ final class Alps
         /** ALPS descriptor ID */
         public readonly string $id,
     ) {
+        assert($id !== '', 'ALPS descriptor ID must not be empty');
     }
 }

--- a/src/Annotation/Alps.php
+++ b/src/Annotation/Alps.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc\Annotation;
+
+use Attribute;
+
+/**
+ * Maps REST resource/method to ALPS semantic descriptor
+ *
+ * On class: Maps to ALPS Taxonomy (state)
+ * On method: Maps to ALPS Choreography (transition)
+ *
+ * @see https://alps-io.github.io/spec/
+ */
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+final class Alps
+{
+    public function __construct(
+        /** ALPS descriptor ID */
+        public readonly string $id,
+    ) {
+    }
+}

--- a/src/DocClass.php
+++ b/src/DocClass.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ApiDoc;
 
 use ArrayObject;
+use BEAR\ApiDoc\Annotation\Alps;
 use BEAR\Resource\Annotation\JsonSchema;
 use ReflectionClass;
 use ReflectionMethod;
@@ -45,6 +46,7 @@ final class DocClass
         $this->semanticDictionary = $semanticDictionary;
         $docComment = (string) $class->getDocComment();
         [$summary, $description, $links] = (new PhpDoc())($docComment);
+        $alpsSection = $this->getAlpsSection($class);
         $methods = $class->getMethods();
         $views = [];
         foreach ($methods as $method) {
@@ -61,9 +63,46 @@ final class DocClass
 <a href="../index.{$ext}" style="color: black; text-decoration: none;">{$title}</a>
 
 # {$path}
-{$summary}{$description}{$links}
+{$alpsSection}{$summary}{$description}{$links}
 {$methodsView}
 EOT;
+    }
+
+    /**
+     * @param ReflectionClass<object> $class
+     */
+    private function getAlpsSection(ReflectionClass $class): string
+    {
+        $attributes = $class->getAttributes(Alps::class);
+        if ($attributes === []) {
+            return '';
+        }
+
+        $ids = [];
+        foreach ($attributes as $attribute) {
+            $alps = $attribute->newInstance();
+            $ids[] = $alps->id;
+        }
+
+        $alpsIds = implode(', ', $ids);
+        $semanticInfo = $this->getSemanticInfo($ids);
+
+        return sprintf("**ALPS**: `%s`%s\n\n", $alpsIds, $semanticInfo);
+    }
+
+    /**
+     * @param array<string> $ids
+     */
+    private function getSemanticInfo(array $ids): string
+    {
+        $info = [];
+        foreach ($ids as $id) {
+            if (isset($this->semanticDictionary[$id])) {
+                $info[] = $this->semanticDictionary[$id];
+            }
+        }
+
+        return $info !== [] ? ' - ' . implode(', ', $info) : '';
     }
 
     private function getMethodView(ReflectionMethod $method, string $ext): string

--- a/src/DocMethod.php
+++ b/src/DocMethod.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ApiDoc;
 
 use ArrayObject;
+use BEAR\ApiDoc\Annotation\Alps;
 use BEAR\Resource\Annotation\Embed;
 use BEAR\Resource\Annotation\Link;
 use phpDocumentor\Reflection\DocBlock;
@@ -42,8 +43,8 @@ final class DocMethod implements Stringable
         private readonly ReflectionMethod $method,
         ?Schema $request,
         private readonly ?Schema $response,
-        ArrayObject $semanticDictionary,
-        private readonly string $ext
+        private readonly ArrayObject $semanticDictionary,
+        private readonly string $ext,
     ) {
         $this->httpMethod = substr($this->method->name, 2);
         $factory = DocBlockFactory::createInstance();
@@ -101,9 +102,10 @@ final class DocMethod implements Stringable
     {
         $title = $this->title;
         $description = $this->description;
+        $alpsSection = $this->getAlpsSection();
         $format = <<<EOT
 ## %s
-{$this->lineString($title)}{$this->lineString($description)}
+{$this->lineString($title)}{$this->lineString($description)}{$alpsSection}
 
 **Request**
 
@@ -257,5 +259,39 @@ EOT;
 {$examples}
 </pre>
 EOT;
+    }
+
+    private function getAlpsSection(): string
+    {
+        $attributes = $this->method->getAttributes(Alps::class);
+        if ($attributes === []) {
+            return '';
+        }
+
+        $ids = [];
+        foreach ($attributes as $attribute) {
+            $alps = $attribute->newInstance();
+            $ids[] = $alps->id;
+        }
+
+        $alpsIds = implode(', ', $ids);
+        $semanticInfo = $this->getAlpsSemanticInfo($ids);
+
+        return sprintf("**ALPS**: `%s`%s\n\n", $alpsIds, $semanticInfo);
+    }
+
+    /**
+     * @param array<string> $ids
+     */
+    private function getAlpsSemanticInfo(array $ids): string
+    {
+        $info = [];
+        foreach ($ids as $id) {
+            if (isset($this->semanticDictionary[$id])) {
+                $info[] = $this->semanticDictionary[$id];
+            }
+        }
+
+        return $info !== [] ? ' - ' . implode(', ', $info) : '';
     }
 }


### PR DESCRIPTION
## Summary

- Add `#[Alps]` attribute to map REST resources/methods to ALPS semantic descriptors
- On class: Maps to ALPS Taxonomy (state)
- On method: Maps to ALPS Choreography (transition)

## Usage

```php
use BEAR\ApiDoc\Annotation\Alps;

#[Alps('User')]
class User extends ResourceObject
{
    #[Alps('goUser')]
    public function onGet(string $id): static { }

    #[Alps('doModifyUser')]
    public function onPut(string $id, string $userName): static { }

    #[Alps('doRemoveUser')]
    public function onDelete(string $id): static { }
}
```

## Benefits

- Maps REST (how) to ALPS domain vocabulary (what)
- `#[Link(rel: 'goUser', ...)]` can use ALPS IDs for consistency
- Improves AI understanding of API semantics

See https://www.app-state-diagram.com/llms.txt for the detail of ALPS.