### PR TITLE
Add reusable GitHub Actions workflow for API documentation

### DIFF
--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -8,7 +8,7 @@ on:
         default: '8.2'
       format:
         type: string
-        default: 'html'  # Comma-separated: html, md, openapi, alps
+        default: 'apidoc'  # Comma-separated: apidoc, md, openapi, alps
       alps-profile:
         type: string
         default: ''  # ALPS profile path (required when format: alps)
@@ -30,16 +30,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # PHP steps (for html, md, openapi formats)
-      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+      # PHP steps (for apidoc, md, openapi formats)
+      - if: contains(inputs.format, 'apidoc') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ inputs.php-version }}
 
-      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+      - if: contains(inputs.format, 'apidoc') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
         run: composer install --prefer-dist --no-progress
 
-      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+      - if: contains(inputs.format, 'apidoc') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
         run: |
           if [ -f "./vendor/bin/apidoc" ]; then
             ./vendor/bin/apidoc
@@ -57,11 +57,11 @@ jobs:
       # OpenAPI to HTML conversion
       - if: contains(inputs.format, 'openapi')
         run: |
-          if [ -f "${{ inputs.docs-path }}/openapi.json" ]; then
+          if [ -f "${{ inputs.docs-path }}/openapi/openapi.json" ]; then
             npm install -g @redocly/cli
-            redocly build-docs ${{ inputs.docs-path }}/openapi.json -o ${{ inputs.docs-path }}/index.html
+            redocly build-docs ${{ inputs.docs-path }}/openapi/openapi.json -o ${{ inputs.docs-path }}/openapi/index.html
           else
-            echo "::error::${{ inputs.docs-path }}/openapi.json not found."
+            echo "::error::${{ inputs.docs-path }}/openapi/openapi.json not found."
             exit 1
           fi
 
@@ -70,10 +70,12 @@ jobs:
         run: |
           if [ -f "${{ inputs.alps-profile }}" ]; then
             npm install -g @alps-asd/app-state-diagram
-            mkdir -p ${{ inputs.docs-path }}
-            asd --echo ${{ inputs.alps-profile }} > ${{ inputs.docs-path }}/index.html
+            mkdir -p ${{ inputs.docs-path }}/alps
+            cp ${{ inputs.alps-profile }} ${{ inputs.docs-path }}/alps/
+            asd --echo ${{ inputs.alps-profile }} > ${{ inputs.docs-path }}/alps/index.html
           else
-            echo "::warning::${{ inputs.alps-profile }} not found. Skipping ALPS conversion."
+            echo "::error::${{ inputs.alps-profile }} not found."
+            exit 1
           fi
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -40,10 +40,12 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
-        run: composer require --dev bear/api-doc
-
-      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
-        run: ./vendor/bin/apidoc
+        run: |
+          if [ -f "./vendor/bin/apidoc" ]; then
+            ./vendor/bin/apidoc
+          else
+            echo "::warning::vendor/bin/apidoc not found. Run 'composer require --dev bear/api-doc' first."
+          fi
 
       # Node.js steps (for openapi and alps formats)
       - if: contains(inputs.format, 'openapi') || contains(inputs.format, 'alps')

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -1,0 +1,92 @@
+name: API Documentation
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        type: string
+        default: '8.2'
+      format:
+        type: string
+        default: 'html'  # Comma-separated: html, md, openapi, alps
+      alps-profile:
+        type: string
+        default: ''  # ALPS profile path (required when format: alps)
+      docs-path:
+        type: string
+        default: 'docs/api'
+      publish-to:
+        type: string
+        default: 'github-pages'  # github-pages or artifact-only
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # PHP steps (for html, md, openapi formats)
+      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php-version }}
+
+      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+        run: composer install --prefer-dist --no-progress
+
+      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+        run: composer require --dev bear/api-doc
+
+      - if: contains(inputs.format, 'html') || contains(inputs.format, 'md') || contains(inputs.format, 'openapi')
+        run: ./vendor/bin/apidoc
+
+      # Node.js steps (for openapi and alps formats)
+      - if: contains(inputs.format, 'openapi') || contains(inputs.format, 'alps')
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # OpenAPI to HTML conversion
+      - if: contains(inputs.format, 'openapi')
+        run: npm install -g @redocly/cli
+
+      - if: contains(inputs.format, 'openapi')
+        run: redocly build-docs ${{ inputs.docs-path }}/openapi.json -o ${{ inputs.docs-path }}/index.html
+
+      # ALPS to HTML conversion
+      - if: contains(inputs.format, 'alps')
+        run: npm install -g @alps-asd/app-state-diagram
+
+      - if: contains(inputs.format, 'alps')
+        run: |
+          mkdir -p ${{ inputs.docs-path }}
+          asd --echo ${{ inputs.alps-profile }} > ${{ inputs.docs-path }}/index.html
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-docs
+          path: ${{ inputs.docs-path }}
+
+      - if: inputs.publish-to == 'github-pages'
+        uses: actions/configure-pages@v4
+
+      - if: inputs.publish-to == 'github-pages'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ inputs.docs-path }}
+
+  deploy:
+    if: inputs.publish-to == 'github-pages'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -55,19 +55,24 @@ jobs:
 
       # OpenAPI to HTML conversion
       - if: contains(inputs.format, 'openapi')
-        run: npm install -g @redocly/cli
-
-      - if: contains(inputs.format, 'openapi')
-        run: redocly build-docs ${{ inputs.docs-path }}/openapi.json -o ${{ inputs.docs-path }}/index.html
+        run: |
+          if [ -f "${{ inputs.docs-path }}/openapi.json" ]; then
+            npm install -g @redocly/cli
+            redocly build-docs ${{ inputs.docs-path }}/openapi.json -o ${{ inputs.docs-path }}/index.html
+          else
+            echo "::warning::${{ inputs.docs-path }}/openapi.json not found. Skipping Redocly conversion."
+          fi
 
       # ALPS to HTML conversion
       - if: contains(inputs.format, 'alps')
-        run: npm install -g @alps-asd/app-state-diagram
-
-      - if: contains(inputs.format, 'alps')
         run: |
-          mkdir -p ${{ inputs.docs-path }}
-          asd --echo ${{ inputs.alps-profile }} > ${{ inputs.docs-path }}/index.html
+          if [ -f "${{ inputs.alps-profile }}" ]; then
+            npm install -g @alps-asd/app-state-diagram
+            mkdir -p ${{ inputs.docs-path }}
+            asd --echo ${{ inputs.alps-profile }} > ${{ inputs.docs-path }}/index.html
+          else
+            echo "::warning::${{ inputs.alps-profile }} not found. Skipping ALPS conversion."
+          fi
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/apidoc.yml
+++ b/.github/workflows/apidoc.yml
@@ -44,7 +44,8 @@ jobs:
           if [ -f "./vendor/bin/apidoc" ]; then
             ./vendor/bin/apidoc
           else
-            echo "::warning::vendor/bin/apidoc not found. Run 'composer require --dev bear/api-doc' first."
+            echo "::error::vendor/bin/apidoc not found. Run 'composer require --dev bear/api-doc' first."
+            exit 1
           fi
 
       # Node.js steps (for openapi and alps formats)
@@ -60,7 +61,8 @@ jobs:
             npm install -g @redocly/cli
             redocly build-docs ${{ inputs.docs-path }}/openapi.json -o ${{ inputs.docs-path }}/index.html
           else
-            echo "::warning::${{ inputs.docs-path }}/openapi.json not found. Skipping Redocly conversion."
+            echo "::error::${{ inputs.docs-path }}/openapi.json not found."
+            exit 1
           fi
 
       # ALPS to HTML conversion

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -6,8 +6,19 @@ on:
 
 jobs:
   test-html:
-    uses: ./.github/workflows/apidoc.yml
-    with:
-      format: 'html'
-      docs-path: 'docs/api'
-      publish-to: 'artifact-only'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - run: composer install --prefer-dist --no-progress
+
+      - run: ./bin/apidoc -c tests/apidoc.html.xml
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-html
+          path: docs

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -37,8 +37,8 @@ jobs:
       - run: npm install -g @alps-asd/app-state-diagram
       - run: |
           mkdir -p docs/alps
-          cp docs/alps.json docs/alps/
-          asd --echo docs/alps.json > docs/alps/index.html
+          cp tests/Fake/app/alps.json docs/alps/
+          asd --echo docs/alps/alps.json > docs/alps/index.html
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -6,19 +6,23 @@ on:
 
 jobs:
   test-html:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+    uses: ./.github/workflows/apidoc.yml
+    with:
+      format: 'html'
+      docs-path: 'docs/html'
+      publish-to: 'artifact-only'
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
+  test-openapi:
+    uses: ./.github/workflows/apidoc.yml
+    with:
+      format: 'openapi'
+      docs-path: 'docs/openapi'
+      publish-to: 'artifact-only'
 
-      - run: composer install --prefer-dist --no-progress
-
-      - run: ./bin/apidoc -c tests/apidoc.html.xml
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: api-docs-html
-          path: docs
+  test-alps:
+    uses: ./.github/workflows/apidoc.yml
+    with:
+      format: 'alps'
+      alps-profile: 'docs/alps.json'
+      docs-path: 'docs/alps'
+      publish-to: 'artifact-only'

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           node-version: '20'
 
-      # HTML (output: docs/)
+      # apidoc (output: docs/)
       - run: ./vendor/bin/apidoc -c=tests/apidoc.html.xml
 
       # OpenAPI (output: docs/openapi/)
@@ -35,7 +35,10 @@ jobs:
 
       # ALPS (output: docs/alps/)
       - run: npm install -g @alps-asd/app-state-diagram
-      - run: mkdir -p docs/alps && asd --echo docs/alps.json > docs/alps/index.html
+      - run: |
+          mkdir -p docs/alps
+          cp docs/alps.json docs/alps/
+          asd --echo docs/alps.json > docs/alps/index.html
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -28,7 +28,7 @@ jobs:
       # OpenAPI
       - run: ./vendor/bin/apidoc -c=tests/apidoc.openapi.xml
       - run: npm install -g @redocly/cli
-      - run: redocly build-docs docs/openapi/openapi.json -o docs/openapi/index.html
+      - run: redocly build-docs tests/docs/openapi/openapi.json -o tests/docs/openapi/index.html
 
       # ALPS
       - run: npm install -g @alps-asd/app-state-diagram

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -5,10 +5,9 @@ on:
     branches: [deploy]
 
 jobs:
-  test-alps:
+  test-html:
     uses: ./.github/workflows/apidoc.yml
     with:
-      format: 'alps'
-      alps-profile: 'docs/alps.json'
+      format: 'html'
       docs-path: 'docs/api'
       publish-to: 'artifact-only'

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -22,30 +22,31 @@ jobs:
         with:
           node-version: '20'
 
-      # HTML
+      # HTML (output: docs/)
       - run: ./vendor/bin/apidoc -c=tests/apidoc.html.xml
 
-      # OpenAPI
+      # OpenAPI (output: docs/openapi/)
       - run: ./vendor/bin/apidoc -c=tests/apidoc.openapi.xml
       - run: npm install -g @redocly/cli
-      - run: redocly build-docs tests/docs/openapi/openapi.json -o tests/docs/openapi/index.html
+      - run: |
+          mkdir -p docs/openapi
+          cp tests/docs/openapi/openapi.json docs/openapi/
+          redocly build-docs docs/openapi/openapi.json -o docs/openapi/index.html
 
-      # ALPS
+      # ALPS (output: docs/alps/)
       - run: npm install -g @alps-asd/app-state-diagram
       - run: mkdir -p docs/alps && asd --echo docs/alps.json > docs/alps/index.html
 
       - uses: actions/upload-artifact@v4
         with:
           name: api-docs-all
-          path: |
-            docs
-            tests/docs
+          path: docs
 
       - uses: actions/configure-pages@v4
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: tests/docs
+          path: docs
 
   deploy:
     needs: test-all-formats

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -5,43 +5,36 @@ on:
     branches: [deploy]
 
 jobs:
-  test-alps:
-    uses: ./.github/workflows/apidoc.yml
-    with:
-      format: 'alps'
-      alps-profile: 'docs/alps.json'
-      docs-path: 'docs/alps'
-      publish-to: 'artifact-only'
-
-  test-html:
+  test-all-formats:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.2'
-      - run: composer install --prefer-dist --no-progress
-      - run: ./bin/apidoc -c tests/apidoc.html.xml
-      - uses: actions/upload-artifact@v4
-        with:
-          name: api-docs-html
-          path: docs
 
-  test-openapi:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+
       - run: composer install --prefer-dist --no-progress
-      - run: ./bin/apidoc -c tests/apidoc.openapi.xml
+
+      - run: mkdir -p vendor/bin && ln -s $(pwd)/bin/apidoc vendor/bin/apidoc
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      # HTML
+      - run: ./vendor/bin/apidoc -c tests/apidoc.html.xml
+
+      # OpenAPI
+      - run: ./vendor/bin/apidoc -c tests/apidoc.openapi.xml
       - run: npm install -g @redocly/cli
       - run: redocly build-docs docs/openapi/openapi.json -o docs/openapi/index.html
+
+      # ALPS
+      - run: npm install -g @alps-asd/app-state-diagram
+      - run: mkdir -p docs/alps && asd --echo docs/alps.json > docs/alps/index.html
+
       - uses: actions/upload-artifact@v4
         with:
-          name: api-docs-openapi
-          path: docs/openapi
+          name: api-docs-all
+          path: docs

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -1,0 +1,22 @@
+name: Test API Documentation Workflow
+
+on:
+  workflow_dispatch:
+    inputs:
+      format:
+        description: 'Output format (comma-separated: html, md, openapi, alps)'
+        required: true
+        default: 'html'
+      alps-profile:
+        description: 'ALPS profile path (required for alps format)'
+        required: false
+        default: 'docs/alps.json'
+
+jobs:
+  test:
+    uses: ./.github/workflows/apidoc.yml
+    with:
+      format: ${{ inputs.format }}
+      alps-profile: ${{ inputs.alps-profile }}
+      docs-path: 'docs/api'
+      publish-to: 'artifact-only'

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: '8.4'
 
       - run: composer install --prefer-dist --no-progress
 

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -37,4 +37,25 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: api-docs-all
-          path: docs
+          path: |
+            docs
+            tests/docs
+
+      - uses: actions/configure-pages@v4
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: tests/docs
+
+  deploy:
+    needs: test-all-formats
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -12,3 +12,36 @@ jobs:
       alps-profile: 'docs/alps.json'
       docs-path: 'docs/alps'
       publish-to: 'artifact-only'
+
+  test-html:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - run: composer install --prefer-dist --no-progress
+      - run: ./bin/apidoc -c tests/apidoc.html.xml
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-html
+          path: docs
+
+  test-openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - run: composer install --prefer-dist --no-progress
+      - run: ./bin/apidoc -c tests/apidoc.openapi.xml
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install -g @redocly/cli
+      - run: redocly build-docs docs/openapi/openapi.json -o docs/openapi/index.html
+      - uses: actions/upload-artifact@v4
+        with:
+          name: api-docs-openapi
+          path: docs/openapi

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -1,22 +1,14 @@
 name: Test API Documentation Workflow
 
 on:
-  workflow_dispatch:
-    inputs:
-      format:
-        description: 'Output format (comma-separated: html, md, openapi, alps)'
-        required: true
-        default: 'html'
-      alps-profile:
-        description: 'ALPS profile path (required for alps format)'
-        required: false
-        default: 'docs/alps.json'
+  push:
+    branches: [deploy]
 
 jobs:
-  test:
+  test-alps:
     uses: ./.github/workflows/apidoc.yml
     with:
-      format: ${{ inputs.format }}
-      alps-profile: ${{ inputs.alps-profile }}
+      format: 'alps'
+      alps-profile: 'docs/alps.json'
       docs-path: 'docs/api'
       publish-to: 'artifact-only'

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -5,20 +5,6 @@ on:
     branches: [deploy]
 
 jobs:
-  test-html:
-    uses: ./.github/workflows/apidoc.yml
-    with:
-      format: 'html'
-      docs-path: 'docs/html'
-      publish-to: 'artifact-only'
-
-  test-openapi:
-    uses: ./.github/workflows/apidoc.yml
-    with:
-      format: 'openapi'
-      docs-path: 'docs/openapi'
-      publish-to: 'artifact-only'
-
   test-alps:
     uses: ./.github/workflows/apidoc.yml
     with:

--- a/.github/workflows/test-apidoc.yml
+++ b/.github/workflows/test-apidoc.yml
@@ -23,10 +23,10 @@ jobs:
           node-version: '20'
 
       # HTML
-      - run: ./vendor/bin/apidoc -c tests/apidoc.html.xml
+      - run: ./vendor/bin/apidoc -c=tests/apidoc.html.xml
 
       # OpenAPI
-      - run: ./vendor/bin/apidoc -c tests/apidoc.openapi.xml
+      - run: ./vendor/bin/apidoc -c=tests/apidoc.openapi.xml
       - run: npm install -g @redocly/cli
       - run: redocly build-docs docs/openapi/openapi.json -o docs/openapi/index.html
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,49 @@ This not only saves you the trouble of writing IDL, but also allows you to gener
 
 See the [API doc documentatiom](http://bearsunday.github.io/manuals/1.0/en/apidoc.html).
 
+## GitHub Actions
+
+You can use the reusable workflow to generate and publish API documentation automatically.
+
+```yaml
+name: API Docs
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docs:
+    uses: bearsunday/BEAR.ApiDoc/.github/workflows/apidoc.yml@v1
+    with:
+      format: 'apidoc,openapi,alps'
+      alps-profile: 'alps.json'
+```
+
+### Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `php-version` | `'8.2'` | PHP version |
+| `format` | `'apidoc'` | Comma-separated: apidoc, md, openapi, alps |
+| `alps-profile` | `''` | ALPS profile path (required for alps format) |
+| `docs-path` | `'docs/api'` | Output directory |
+| `publish-to` | `'github-pages'` | `github-pages` or `artifact-only` |
+
+### Output Structure
+
+```
+docs/
+├── index.html          # apidoc
+├── schema/             # JSON Schema
+│   └── *.json
+├── openapi/
+│   ├── openapi.json    # OpenAPI spec
+│   └── index.html      # Redocly HTML
+└── alps/
+    ├── alps.json       # ALPS profile
+    └── index.html      # ASD HTML
+```
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ jobs:
 
 ### Output Structure
 
-```
+```text
 docs/
 ├── index.html          # apidoc
 ├── schema/             # JSON Schema

--- a/tests/apidoc.html.xml
+++ b/tests/apidoc.html.xml
@@ -11,8 +11,8 @@
     <links>
         <link rel="home" href="https://github.com/bearsunday/BEAR.ApiDoc" />
         <link rel="issues" href="https://github.com/bearsunday/BEAR.ApiDoc/issues" />
-        <link rel="profile" href="alps.html" />
-        <link rel="openapi" href="openapi.json" />
-        <link rel="openapi-html" href="openapi.html" />
+        <link rel="profile" href="alps/" />
+        <link rel="openapi" href="openapi/openapi.json" />
+        <link rel="openapi-html" href="openapi/" />
     </links>
 </apidoc>


### PR DESCRIPTION
## Summary

- Add reusable workflow for generating and publishing API documentation
- Support multiple formats: apidoc, md, openapi, alps
- Auto-convert OpenAPI to HTML (Redocly) and ALPS to HTML (asd)
- Deploy to GitHub Pages or artifact-only

## Inputs

| Input | Default | Description |
|-------|---------|-------------|
| `php-version` | `'8.2'` | PHP version |
| `format` | `'apidoc'` | Comma-separated: apidoc, md, openapi, alps |
| `alps-profile` | `''` | ALPS profile path (required for alps format) |
| `docs-path` | `'docs/api'` | Output directory |
| `publish-to` | `'github-pages'` | `github-pages` or `artifact-only` |

## Output Structure

```
docs/
├── index.html          # apidoc
├── schema/             # JSON Schema
│   └── *.json
├── openapi/
│   ├── openapi.json    # OpenAPI spec
│   └── index.html      # Redocly HTML
└── alps/
    ├── alps.json       # ALPS profile
    └── index.html      # ASD HTML
```

## Usage Example

```yaml
name: API Docs
on:
  push:
    branches: [main]

jobs:
  docs:
    uses: bearsunday/BEAR.ApiDoc/.github/workflows/apidoc.yml@v1
    with:
      format: 'apidoc,openapi,alps'
      alps-profile: 'alps.json'
```

## Test Plan

- [x] Test apidoc format
- [x] Test OpenAPI format with Redocly conversion
- [x] Test ALPS format with asd conversion
- [x] Deploy to GitHub Pages