### PR TITLE
feat: add Type column and improve HTML documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This not only saves you the trouble of writing IDL, but also allows you to gener
 
 ## Demo
 
-[Live Demo](https://bearsunday.github.io/BEAR.ApiDoc/)
+- [ApiDoc](https://bearsunday.github.io/BEAR.ApiDoc/)
+- [OpenAPI](https://bearsunday.github.io/BEAR.ApiDoc/openapi/)
 
 ## Installation
 

--- a/docs/apidoc.css
+++ b/docs/apidoc.css
@@ -174,6 +174,11 @@ tr:hover {
     border: 1px solid;
 }
 
+.badge[class*="type-"] {
+    min-width: 45px;
+    text-align: center;
+}
+
 .badge.type-string {
     background: #EAF5FF;
     border-color: #5C9EE8;

--- a/docs/index.html
+++ b/docs/index.html
@@ -56,7 +56,7 @@
   <td><div class="extra-info">
       
     </div></td>
-  <td rowspan="1"><a href="#Calendar Event" class="schema-link">Calendar Event</a></td>
+  <td rowspan="1"><a href="#CalendarEvent" class="schema-link">Calendar Event</a></td>
 </tr>
 <tr>
   <td rowspan="1" class="path-cell" id="path-card">/card</td>
@@ -320,7 +320,7 @@
   <td></td>
   <td></td>
   <td></td>
-  <td><a href="#Collection of Tickets" class="schema-link">Collection of Tickets</a></td>
+  <td><a href="#CollectionofTickets" class="schema-link">Collection of Tickets</a></td>
 </tr>
 <tr>
   <td rowspan="11" class="path-cell" id="path-users/{id}">/users/{id}</td>
@@ -607,7 +607,7 @@
 </tbody>
 </table>
 </div>
-<div class="object-section" id="Calendar Event">
+<div class="object-section" id="CalendarEvent">
 <h3 class="object-name">Calendar Event</h3>
 <table>
 <thead>
@@ -1040,7 +1040,7 @@
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti unsafe"></span><a href="#Delete">doDelete</a></td>
+  <td class="prop-name"><span class="ti unsafe"></span>doDelete</td>
   <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
@@ -1133,7 +1133,7 @@
     </div></td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span><a href="#Assignee">goAssignee</a></td>
+  <td class="prop-name"><span class="ti safe"></span>goAssignee</td>
   <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
@@ -1246,7 +1246,7 @@
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span><a href="#Calendar">goCalendar</a></td>
+  <td class="prop-name"><span class="ti safe"></span>goCalendar</td>
   <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
@@ -1266,7 +1266,7 @@
 <h3 class="object-name">Numbers</h3>
 <p class="array-type">array of <a href="#Integer">Integer</a></p>
 </div>
-<div class="object-section" id="Collection of Tickets">
+<div class="object-section" id="CollectionofTickets">
 <h3 class="object-name">Collection of Tickets</h3>
 <p class="array-type">array of <a href="#Ticket">Ticket</a></p>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,6 +18,7 @@
   <th>Path</th>
   <th>Method</th>
   <th>Params</th>
+  <th>Type</th>
   <th>Description</th>
   <th>Meta</th>
   <th>Response</th>
@@ -25,47 +26,51 @@
 </thead>
 <tbody>
 <tr>
-  <td rowspan="1" class="path-cell">/address</td>
+  <td rowspan="1" class="path-cell" id="path-address">/address</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get address</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Address ID</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
   <td rowspan="1"><a href="#Address" class="schema-link">Address</a></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/array-data</td>
+  <td rowspan="1" class="path-cell" id="path-array-data">/array-data</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get array data</div></td>
   <td><span class="param">items</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">List of item IDs to retrieve</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
+      
     </div></td>
   <td rowspan="1"><a href="#Groceries" class="schema-link">Groceries</a></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/calendar</td>
+  <td rowspan="1" class="path-cell" id="path-calendar">/calendar</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get schedule</div></td>
   <td><span class="param">date</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Target date (YYYY-MM-DD format)</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
-  <td rowspan="1"><a href="#CalendarEvent" class="schema-link">CalendarEvent</a></td>
+  <td rowspan="1"><a href="#Calendar Event" class="schema-link">Calendar Event</a></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/card</td>
+  <td rowspan="1" class="path-cell" id="path-card">/card</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get card</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Card ID</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
   <td rowspan="1"><a href="#Card" class="schema-link">Card</a></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/index</td>
+  <td rowspan="1" class="path-cell" id="path-index">/index</td>
   <td class="method-cell"><span class="ti safe"></span>GET<div class="method-title">API entry point</div></td>
   <td></td>
   <td></td>
@@ -73,43 +78,45 @@
   <td></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/numbers</td>
+  <td rowspan="1" class="path-cell" id="path-numbers">/numbers</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get numbers</div></td>
   <td><span class="param">count</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Number of items to return</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
+      
     </div></td>
   <td rowspan="1"><a href="#Numbers" class="schema-link">Numbers</a></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/org</td>
+  <td rowspan="1" class="path-cell" id="path-org">/org</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get organization</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Organization ID</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
   <td rowspan="1"><a href="#Org" class="schema-link">Org</a></td>
 </tr>
 <tr>
-  <td rowspan="8" class="path-cell">/person</td>
-  <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get person</div><div class="method-alps"><a href="alps.html#goPerson" class="alps-link">goPerson</a></div></td>
+  <td rowspan="8" class="path-cell" id="path-person">/person</td>
+  <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get person</div><div class="method-alps"><a href="alps/#goPerson" class="alps-link">goPerson</a></div></td>
   <td><span class="param">id</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier of the person</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: person_12345</span>
     </div></td>
   <td rowspan="1"><a href="#Person" class="schema-link">Person</a></td>
 </tr>
 <tr>
   
-  <td rowspan="3" class="method-cell"><span class="ti unsafe"></span>POST<div class="method-title">Register member</div><div class="method-alps"><a href="alps.html#doCreatePerson" class="alps-link">doCreatePerson</a></div></td>
+  <td rowspan="3" class="method-cell"><span class="ti unsafe"></span>POST<div class="method-title">Register member</div><div class="method-alps"><a href="alps/#doCreatePerson" class="alps-link">doCreatePerson</a></div></td>
   <td><span class="param">firstName</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s first/given name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 1</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: John</span>
@@ -120,9 +127,9 @@
   
   
   <td><span class="param">familyName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s family/last name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: Doe</span>
     </div></td>
@@ -132,9 +139,9 @@
   
   
   <td><span class="param">age</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Age in years</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge constraint">minimum: 0</span>
       <span class="badge constraint">maximum: 150</span>
       <span class="badge example">example: 30</span>
@@ -145,9 +152,9 @@
   
   <td rowspan="4" class="method-cell"><span class="ti unsafe"></span>PATCH<div class="method-title">Update profile</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier of the person</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: person_12345</span>
     </div></td>
   <td rowspan="4"></td>
@@ -156,9 +163,9 @@
   
   
   <td><span class="param">firstName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s first/given name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 1</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: John</span>
@@ -169,9 +176,9 @@
   
   
   <td><span class="param">familyName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s family/last name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: Doe</span>
     </div></td>
@@ -181,9 +188,9 @@
   
   
   <td><span class="param">age</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Age in years</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge constraint">minimum: 0</span>
       <span class="badge constraint">maximum: 150</span>
       <span class="badge example">example: 30</span>
@@ -191,12 +198,12 @@
   
 </tr>
 <tr>
-  <td rowspan="10" class="path-cell">/ticket/{id}</td>
+  <td rowspan="10" class="path-cell" id="path-ticket/{id}">/ticket/{id}</td>
   <td rowspan="1" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get a ticket</div><div class="method-desc">Retrieve detailed information about a specific support ticket.</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The unique identifier for a ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: TKT-2024-001</span>
     </div></td>
   <td rowspan="1"><a href="#Ticket" class="schema-link">Ticket</a></td>
@@ -205,9 +212,9 @@
   
   <td rowspan="3" class="method-cell"><span class="ti unsafe"></span>POST<div class="method-title">Create a new ticket</div><div class="method-desc">Create a new support ticket in the system. This endpoint allows you to submit customer inquiries, bug reports, feature requests, and other issues that need to be tracked and resolved by the support team. The ticket will be automatically assigned a unique identifier and timestamps for creation and last update.</div></td>
   <td><span class="param">title</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Brief summary of the issue or request</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 3</span>
       <span class="badge constraint">maxLength: 255</span>
       <span class="badge example">example: Cannot login to dashboard</span>
@@ -218,9 +225,9 @@
   
   
   <td><span class="param">description</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Detailed explanation of the issue</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 2000</span>
       <span class="badge example">example: When I click login, I get a 500 error</span>
     </div></td>
@@ -230,9 +237,9 @@
   
   
   <td><span class="param">assignee</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Username of the support agent</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: john.smith</span>
     </div></td>
   
@@ -241,9 +248,9 @@
   
   <td rowspan="5" class="method-cell"><span class="ti idempotent"></span>PUT<div class="method-title">Update a ticket</div><div class="method-desc">Modify an existing ticket&#039;s information.</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The unique identifier for a ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: TKT-2024-001</span>
     </div></td>
   <td rowspan="5"></td>
@@ -252,9 +259,9 @@
   
   
   <td><span class="param">title</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Brief summary of the issue or request</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 3</span>
       <span class="badge constraint">maxLength: 255</span>
       <span class="badge example">example: Cannot login to dashboard</span>
@@ -265,9 +272,9 @@
   
   
   <td><span class="param">status</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Current status of the ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">enum: [&quot;open&quot;,&quot;in_progress&quot;,&quot;waiting&quot;,&quot;resolved&quot;,&quot;closed&quot;]</span>
       <span class="badge example">example: in_progress</span>
     </div></td>
@@ -277,9 +284,9 @@
   
   
   <td><span class="param">assignee</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Username of the support agent</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: john.smith</span>
     </div></td>
   
@@ -288,9 +295,9 @@
   
   
   <td><span class="param">description</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Detailed explanation of the issue</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 2000</span>
       <span class="badge example">example: When I click login, I get a 500 error</span>
     </div></td>
@@ -300,28 +307,28 @@
   
   <td rowspan="1" class="method-cell"><span class="ti idempotent"></span>DELETE<div class="method-title">Delete a ticket</div><div class="method-desc">Permanently remove a ticket from the system.</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The unique identifier for a ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: TKT-2024-001</span>
     </div></td>
   <td rowspan="1"></td>
 </tr>
 <tr>
-  <td rowspan="1" class="path-cell">/tickets</td>
+  <td rowspan="1" class="path-cell" id="path-tickets">/tickets</td>
   <td class="method-cell"><span class="ti safe"></span>GET</td>
   <td></td>
   <td></td>
   <td></td>
-  <td><a href="#CollectionOfTickets" class="schema-link">CollectionOfTickets</a></td>
+  <td><a href="#Collection of Tickets" class="schema-link">Collection of Tickets</a></td>
 </tr>
 <tr>
-  <td rowspan="11" class="path-cell">/users/{id}</td>
-  <td rowspan="2" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get user profile</div><div class="method-desc">Retrieve detailed profile information for a specific user.</div><div class="method-alps"><a href="alps.html#getUser" class="alps-link">getUser</a></div></td>
+  <td rowspan="11" class="path-cell" id="path-users/{id}">/users/{id}</td>
+  <td rowspan="2" class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get user profile</div><div class="method-desc">Retrieve detailed profile information for a specific user.</div><div class="method-alps"><a href="alps/#getUser" class="alps-link">getUser</a></div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier for the user</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: usr_abc123</span>
     </div></td>
   <td rowspan="2"><a href="#User" class="schema-link">User</a></td>
@@ -330,9 +337,9 @@
   
   
   <td><span class="param">options</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Display options</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">enum: [&quot;guest&quot;,&quot;full&quot;,&quot;minimal&quot;]</span>
       <span class="badge example">example: full</span>
     </div></td>
@@ -340,11 +347,11 @@
 </tr>
 <tr>
   
-  <td rowspan="3" class="method-cell"><span class="ti unsafe"></span>POST<div class="method-title">Create a new user</div><div class="method-desc">Register a new user account in the system.</div><div class="method-alps"><a href="alps.html#createUser" class="alps-link">createUser</a></div></td>
+  <td rowspan="3" class="method-cell"><span class="ti unsafe"></span>POST<div class="method-title">Create a new user</div><div class="method-desc">Register a new user account in the system.</div><div class="method-alps"><a href="alps/#createUser" class="alps-link">createUser</a></div></td>
   <td><span class="param">name</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Display name of the user</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Jane Smith</span>
     </div></td>
   <td rowspan="3"></td>
@@ -353,9 +360,9 @@
   
   
   <td><span class="param">age</span><span class="req">*</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Age of the user in years</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge constraint">minimum: 0</span>
       <span class="badge constraint">maximum: 150</span>
       <span class="badge example">example: 29</span>
@@ -366,9 +373,9 @@
   
   
   <td><span class="param">email</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Email address for the account</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: email</span>
       <span class="badge example">example: jane.smith@example.com</span>
     </div></td>
@@ -376,11 +383,11 @@
 </tr>
 <tr>
   
-  <td rowspan="5" class="method-cell"><span class="ti idempotent"></span>PUT<div class="method-title">Update user profile</div><div class="method-desc">Modify existing user account information.</div><div class="method-alps"><a href="alps.html#updateUser" class="alps-link">updateUser</a></div></td>
+  <td rowspan="5" class="method-cell"><span class="ti idempotent"></span>PUT<div class="method-title">Update user profile</div><div class="method-desc">Modify existing user account information.</div><div class="method-alps"><a href="alps/#updateUser" class="alps-link">updateUser</a></div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier for the user</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: usr_abc123</span>
     </div></td>
   <td rowspan="5"></td>
@@ -389,9 +396,9 @@
   
   
   <td><span class="param">name</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Display name of the user</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Jane Smith</span>
     </div></td>
   
@@ -400,9 +407,9 @@
   
   
   <td><span class="param">age</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Age of the user in years</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge constraint">minimum: 0</span>
       <span class="badge constraint">maximum: 150</span>
       <span class="badge example">example: 29</span>
@@ -413,9 +420,9 @@
   
   
   <td><span class="param">email</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Email address for the account</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: email</span>
       <span class="badge example">example: jane.smith@example.com</span>
     </div></td>
@@ -425,31 +432,32 @@
   
   
   <td><span class="param">enabled</span></td>
+  <td><span class="badge type-bool">bool</span></td>
   <td class="param-desc">Whether the account is active</td>
   <td><div class="extra-info">
-      <span class="badge type-bool">bool</span>
       <span class="badge example">example: true</span>
     </div></td>
   
 </tr>
 <tr>
   
-  <td rowspan="1" class="method-cell"><span class="ti idempotent"></span>DELETE<div class="method-title">Delete user account</div><div class="method-desc">Permanently delete a user account and associated data.</div><div class="method-alps"><a href="alps.html#deleteUser" class="alps-link">deleteUser</a></div></td>
+  <td rowspan="1" class="method-cell"><span class="ti idempotent"></span>DELETE<div class="method-title">Delete user account</div><div class="method-desc">Permanently delete a user account and associated data.</div><div class="method-alps"><a href="alps/#deleteUser" class="alps-link">deleteUser</a></div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier for the user</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: usr_abc123</span>
     </div></td>
   <td rowspan="1"></td>
 </tr>
 <tr>
-  <td rowspan="2" class="path-cell">/ticket/assign</td>
+  <td rowspan="2" class="path-cell" id="path-ticket/assign">/ticket/assign</td>
   <td rowspan="2" class="method-cell"><span class="ti idempotent"></span>PUT<div class="method-title">Assign ticket</div><div class="method-desc">CQRS domain command. Compare with CRUD operations at /ticket.</div></td>
   <td><span class="param">id</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Ticket ID</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
   <td rowspan="2"></td>
 </tr>
@@ -457,9 +465,10 @@
   
   
   <td><span class="param">assignee</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Username of the assignee</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
   
 </tr>
@@ -472,64 +481,91 @@
 <h3 class="object-name">Address</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">post-office-box</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Post Office Box - PO Box number for mail delivery</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: PO Box 1234</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">extended-address</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Apartment, suite, or unit number</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Suite 500</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">street-address</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Street number and name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: 123 Main Street</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">locality</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">City or town name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: San Francisco</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">region</span></td>
+  <td><span class="badge type-intstring">int|string</span></td>
   <td class="param-desc">State, province, or region</td>
   <td><div class="extra-info">
-      <span class="badge type-intstring">int|string</span>
       <span class="badge example">example: CA</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">postal-code</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">ZIP or postal code</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">pattern: ^[0-9A-Za-z\- ]+$</span>
       <span class="badge example">example: 94102</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">country-name</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Full country name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: United States</span>
+    </div></td>
+</tr>
+
+</tbody>
+</table>
+</div>
+<div class="object-section" id="Juice">
+<h3 class="object-name">Juice</h3>
+<table>
+<thead>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
+</thead>
+<tbody>
+<tr>
+  <td><span class="prop-name">juiceName</span></td>
+  <td><span class="badge type-string">string</span></td>
+  <td class="param-desc">The name of the juice.</td>
+  <td><div class="extra-info">
+      
+    </div></td>
+</tr>
+<tr>
+  <td><span class="prop-name">juiceLike</span></td>
+  <td><span class="badge type-bool">bool</span></td>
+  <td class="param-desc">Do I like this juice?</td>
+  <td><div class="extra-info">
+      
     </div></td>
 </tr>
 
@@ -540,123 +576,126 @@
 <h3 class="object-name">Groceries</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">fruits</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">List of fruit names</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
+      
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">vegetables</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">List of vegetables with preferences</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
+      
     </div></td>
 </tr>
 <tr>
-  <td><span class="prop-name">juice</span></td>
+  <td><a href="#Juice" class="prop-name">juice</a></td>
+  <td><span class="badge type-object">object</span></td>
   <td class="param-desc">Juice preference details</td>
   <td><div class="extra-info">
-      <span class="badge type-object">object</span>
+      
     </div></td>
 </tr>
 
 </tbody>
 </table>
 </div>
-<div class="object-section" id="CalendarEvent">
-<h3 class="object-name">CalendarEvent</h3>
+<div class="object-section" id="Calendar Event">
+<h3 class="object-name">Calendar Event</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">dtstart</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Event start date and time in ISO 8601 format</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-03-15T10:00:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">dtend</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Event end date and time in ISO 8601 format</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-03-15T11:30:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">summary</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Brief title or name of the event</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 255</span>
       <span class="badge example">example: Weekly Team Meeting</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">location</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Physical location or virtual meeting URL</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Conference Room A / https://meet.example.com/abc</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">url</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">URL with more information about the event</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: uri</span>
       <span class="badge example">example: https://example.com/events/weekly-meeting</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">duration</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Event duration in ISO 8601 duration format</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: PT1H30M</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">rdate</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Additional recurrence date for the event</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-03-22T10:00:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">rrule</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Recurrence rule in iCalendar RRULE format</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: FREQ=WEEKLY;BYDAY=MO,WE,FR;COUNT=10</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">category</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Event category for organization and filtering</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: meeting</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">description</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Detailed description of the event and agenda</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 2000</span>
       <span class="badge example">example: Discuss Q1 progress and plan Q2 objectives.</span>
     </div></td>
@@ -669,22 +708,22 @@
 <h3 class="object-name">Card.Email</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">type</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Category of email (work, home, other)</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: work</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">value</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The email address</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: email</span>
       <span class="badge example">example: jane.smith@company.com</span>
     </div></td>
@@ -697,22 +736,22 @@
 <h3 class="object-name">Card.Tel</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">type</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Category of phone (work, home, mobile, fax)</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: mobile</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">value</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The phone number</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: +1-555-123-4567</span>
     </div></td>
 </tr>
@@ -724,22 +763,22 @@
 <h3 class="object-name">Card.Org</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">organizationName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Name of the organization</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Acme Corporation</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">organizationUnit</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Department or division within organization</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Engineering</span>
     </div></td>
 </tr>
@@ -751,153 +790,156 @@
 <h3 class="object-name">Card</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">fn</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Full formatted name as it should be displayed</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Dr. Jane M. Smith, PhD</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">familyName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Family name (surname/last name)</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Smith</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">givenName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Given name (first name)</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Jane</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">additionalName</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">Middle names or other additional names</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
       <span class="badge example">example: [&quot;Marie&quot;]</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">honorificPrefix</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">Name prefixes and titles (e.g., Dr., Mr., Ms.)</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
       <span class="badge example">example: [&quot;Dr.&quot;]</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">honorificSuffix</span></td>
+  <td><span class="badge type-array">array</span></td>
   <td class="param-desc">Name suffixes and post-nominals (e.g., PhD, Jr., III)</td>
   <td><div class="extra-info">
-      <span class="badge type-array">array</span>
       <span class="badge example">example: [&quot;PhD&quot;,&quot;MBA&quot;]</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">nickname</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Preferred informal name or alias</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Jenny</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">url</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Personal or professional website URL</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: uri</span>
       <span class="badge example">example: https://janesmith.example.com</span>
     </div></td>
 </tr>
 <tr>
-  <td><span class="prop-name">email</span></td>
+  <td><a href="#Card.Email" class="prop-name">email</a></td>
+  <td><span class="badge type-object">object</span></td>
   <td class="param-desc">Email address with type classification</td>
   <td><div class="extra-info">
-      <a href="#Card.Email" class="badge type-object">object</a>
+      
     </div></td>
 </tr>
 <tr>
-  <td><span class="prop-name">tel</span></td>
+  <td><a href="#Card.Tel" class="prop-name">tel</a></td>
+  <td><span class="badge type-object">object</span></td>
   <td class="param-desc">Telephone number with type classification</td>
   <td><div class="extra-info">
-      <a href="#Card.Tel" class="badge type-object">object</a>
+      
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">tz</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Timezone in IANA format or UTC offset</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: America/New_York</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">photo</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">URL to profile photo image</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: uri</span>
       <span class="badge example">example: https://example.com/photos/jsmith.jpg</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">logo</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">URL to company or organization logo</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: uri</span>
       <span class="badge example">example: https://company.com/logo.png</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">sound</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">URL to audio file with name pronunciation</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: uri</span>
       <span class="badge example">example: https://example.com/pronunciation/jsmith.mp3</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">bday</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Birthday in ISO 8601 date format</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date</span>
       <span class="badge example">example: 1985-06-15</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">title</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Job title or position</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Senior Software Engineer</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">role</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Function or role within organization</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Technical Lead</span>
     </div></td>
 </tr>
 <tr>
-  <td><span class="prop-name">org</span></td>
+  <td><a href="#Card.Org" class="prop-name">org</a></td>
+  <td><span class="badge type-object">object</span></td>
   <td class="param-desc">Organization or company affiliation</td>
   <td><div class="extra-info">
-      <a href="#Card.Org" class="badge type-object">object</a>
+      
     </div></td>
 </tr>
 
@@ -908,21 +950,22 @@
 <h3 class="object-name">Org</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">id</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Organization ID</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
+      
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">name</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Organization name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: Acme Inc.</span>
     </div></td>
 </tr>
@@ -934,14 +977,14 @@
 <h3 class="object-name">Person</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">firstName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s first/given name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 1</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: John</span>
@@ -949,59 +992,59 @@
 </tr>
 <tr>
   <td><span class="prop-name">familyName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">The person&#039;s family/last name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: Doe</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">age</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">Age in years (must be 0 or greater)</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge constraint">minimum: 0</span>
       <span class="badge constraint">maximum: 150</span>
       <span class="badge example">example: 30</span>
     </div></td>
 </tr>
 <tr class="embed-row">
-  <td class="prop-name"><span class="ti semantic"></span>org</td>
+  <td class="prop-name"><span class="ti semantic"></span><a href="#Org">org</a></td>
+  <td><span class="badge embed">embed</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge embed">embed</span>
       <span class="badge href">src: /org?id={org_id}</span>
     </div>
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span>goCard</td>
+  <td class="prop-name"><span class="ti safe"></span><a href="#Card">goCard</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /card?id={card_id}</span>
     </div>
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span>goTickets</td>
+  <td class="prop-name"><span class="ti safe"></span><a href="#Ticket">goTickets</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /tickets</span>
     </div>
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti unsafe"></span>doDelete</td>
+  <td class="prop-name"><span class="ti unsafe"></span><a href="#Delete">doDelete</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /person?id={id}</span>
     </div>
   </td>
@@ -1014,22 +1057,22 @@
 <h3 class="object-name">Ticket</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">id</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier for the ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge example">example: TKT-2024-001</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">title</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Brief summary of the issue or request</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">minLength: 3</span>
       <span class="badge constraint">maxLength: 255</span>
       <span class="badge example">example: Cannot login to dashboard</span>
@@ -1037,64 +1080,64 @@
 </tr>
 <tr>
   <td><span class="prop-name">description</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Detailed explanation of the issue including steps to reproduce</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 2000</span>
       <span class="badge example">example: When I click the login button, the page shows a 500 error.</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">assignee</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Username of the support agent handling this ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 50</span>
       <span class="badge example">example: john.smith</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">status</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Current status of the ticket in the workflow</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">enum: [&quot;open&quot;,&quot;in_progress&quot;,&quot;waiting&quot;,&quot;resolved&quot;,&quot;closed&quot;]</span>
       <span class="badge example">example: in_progress</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">priority</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Urgency level of the ticket</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">enum: [&quot;low&quot;,&quot;medium&quot;,&quot;high&quot;,&quot;critical&quot;]</span>
       <span class="badge example">example: high</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">created</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Timestamp when the ticket was created</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-01-15T09:30:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">updated</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Timestamp when the ticket was last modified</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-01-16T14:22:00Z</span>
     </div></td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span>goAssignee</td>
+  <td class="prop-name"><span class="ti safe"></span><a href="#Assignee">goAssignee</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /user{?id}</span>
     </div>
   </td>
@@ -1107,23 +1150,23 @@
 <h3 class="object-name">User</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 <tr>
   <td><span class="prop-name">id</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Unique identifier for the user account</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 30</span>
       <span class="badge example">example: usr_abc123</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">firstName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">User&#039;s first/given name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 30</span>
       <span class="badge constraint">pattern: [a-zA-Z\-&#039;]+</span>
       <span class="badge example">example: Jane</span>
@@ -1131,9 +1174,9 @@
 </tr>
 <tr>
   <td><span class="prop-name">lastName</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">User&#039;s last/family name</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge constraint">maxLength: 30</span>
       <span class="badge constraint">pattern: [a-zA-Z\-&#039;]+</span>
       <span class="badge example">example: Smith</span>
@@ -1141,73 +1184,73 @@
 </tr>
 <tr>
   <td><span class="prop-name">created</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Timestamp when the account was created</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-01-10T08:00:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">modified</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Timestamp of the last profile update</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: date-time</span>
       <span class="badge example">example: 2024-02-15T14:30:00Z</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">email</span></td>
+  <td><span class="badge type-string">string</span></td>
   <td class="param-desc">Primary email address for the account</td>
   <td><div class="extra-info">
-      <span class="badge type-string">string</span>
       <span class="badge format">format: email</span>
       <span class="badge example">example: jane.smith@example.com</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">enabled</span></td>
+  <td><span class="badge type-bool">bool</span></td>
   <td class="param-desc">Whether the account is active and can login</td>
   <td><div class="extra-info">
-      <span class="badge type-bool">bool</span>
       <span class="badge example">example: true</span>
     </div></td>
 </tr>
 <tr>
   <td><span class="prop-name">age</span></td>
+  <td><span class="badge type-int">int</span></td>
   <td class="param-desc">User&#039;s age in years</td>
   <td><div class="extra-info">
-      <span class="badge type-int">int</span>
       <span class="badge example">example: 29</span>
     </div></td>
 </tr>
 <tr class="embed-row">
-  <td class="prop-name"><span class="ti semantic"></span>ticket</td>
+  <td class="prop-name"><span class="ti semantic"></span><a href="#Ticket">ticket</a></td>
+  <td><span class="badge embed">embed</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge embed">embed</span>
       <span class="badge href">src: /ticket/{id}</span>
     </div>
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span>goPerson</td>
+  <td class="prop-name"><span class="ti safe"></span><a href="#Person">goPerson</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /person</span>
     </div>
   </td>
 </tr>
 <tr class="link-row">
-  <td class="prop-name"><span class="ti safe"></span>goCalendar</td>
+  <td class="prop-name"><span class="ti safe"></span><a href="#Calendar">goCalendar</a></td>
+  <td><span class="badge link">link</span></td>
   <td class="param-desc"></td>
   <td>
     <div class="extra-info">
-      <span class="badge link">link</span>
       <span class="badge href">href: /calendar</span>
     </div>
   </td>
@@ -1223,14 +1266,14 @@
 <h3 class="object-name">Numbers</h3>
 <p class="array-type">array of <a href="#Integer">Integer</a></p>
 </div>
-<div class="object-section" id="CollectionOfTickets">
-<h3 class="object-name">CollectionOfTickets</h3>
+<div class="object-section" id="Collection of Tickets">
+<h3 class="object-name">Collection of Tickets</h3>
 <p class="array-type">array of <a href="#Ticket">Ticket</a></p>
 </div>
 
 
 <h2>Links</h2>
-<ul class="doc-links"><li><strong>home</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc">https://github.com/bearsunday/BEAR.ApiDoc</a></li><li><strong>issues</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc/issues">https://github.com/bearsunday/BEAR.ApiDoc/issues</a></li><li><strong>profile</strong> : <a href="alps.html">alps.html</a></li><li><strong>openapi</strong> : <a href="openapi.json">openapi.json</a></li><li><strong>openapi-html</strong> : <a href="openapi.html">openapi.html</a></li></ul>
+<ul class="doc-links"><li><strong>home</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc">https://github.com/bearsunday/BEAR.ApiDoc</a></li><li><strong>issues</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc/issues">https://github.com/bearsunday/BEAR.ApiDoc/issues</a></li><li><strong>profile</strong> : <a href="alps/">alps/</a></li><li><strong>openapi</strong> : <a href="openapi/openapi.json">openapi/openapi.json</a></li><li><strong>openapi-html</strong> : <a href="openapi/">openapi/</a></li></ul>
 
 </div>
 </body>

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -311,6 +311,7 @@ final class HtmlGenerator
         return new Schema($fileInfo, $schemaJson, $emptyDictionary);
     }
 
+    /** @SuppressWarnings("PHPMD.NPathComplexity") */
     private function addObject(string $name, Schema $schema): void
     {
         if (isset($this->objects[$name])) {
@@ -325,6 +326,7 @@ final class HtmlGenerator
         }
 
         // Load raw schema to access definitions
+        /** @psalm-suppress MixedAssignment */
         $schemaJson = json_decode((string) file_get_contents($schema->file->getPathname()));
 
         foreach ($schema->props as $propName => $prop) {
@@ -358,8 +360,11 @@ final class HtmlGenerator
                     $defName = ucfirst(substr($refPath, 14)); // Remove '#/definitions/'
                     $ref = $defName;
                     // Add the definition as an Object if it exists
+                    /** @psalm-suppress MixedPropertyFetch */
                     if (is_object($schemaJson) && isset($schemaJson->definitions->{lcfirst($defName)}) && is_object($schemaJson->definitions->{lcfirst($defName)})) {
+                        /** @psalm-suppress MixedPropertyFetch, MixedAssignment */
                         $definition = $schemaJson->definitions->{lcfirst($defName)};
+                        /** @psalm-suppress MixedPropertyFetch, MixedArgument */
                         if (isset($definition->properties) && is_object($definition->properties)) {
                             $this->addNestedObject($defName, $definition->properties);
                         }

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -23,8 +23,10 @@ use function is_numeric;
 use function is_object;
 use function is_string;
 use function json_decode;
+use function lcfirst;
 use function pathinfo;
 use function sprintf;
+use function str_starts_with;
 use function strtoupper;
 use function substr;
 use function ucfirst;
@@ -322,6 +324,9 @@ final class HtmlGenerator
             $arrayItemType = $this->getArrayItemType($schema);
         }
 
+        // Load raw schema to access definitions
+        $schemaJson = json_decode((string) file_get_contents($schema->file->getPathname()));
+
         foreach ($schema->props as $propName => $prop) {
             if ($propName === '_links') {
                 continue;
@@ -344,6 +349,24 @@ final class HtmlGenerator
                 $this->addNestedObject($nestedName, $constraints['properties']);
                 $ref = $nestedName;
                 unset($constraints['properties']);
+            }
+
+            // Check for $ref to #/definitions/
+            if ($prop->type === 'object' && isset($constraints['$ref']) && is_string($constraints['$ref'])) {
+                $refPath = $constraints['$ref'];
+                if (str_starts_with($refPath, '#/definitions/')) {
+                    $defName = ucfirst(substr($refPath, 14)); // Remove '#/definitions/'
+                    $ref = $defName;
+                    // Add the definition as an Object if it exists
+                    if (is_object($schemaJson) && isset($schemaJson->definitions->{lcfirst($defName)}) && is_object($schemaJson->definitions->{lcfirst($defName)})) {
+                        $definition = $schemaJson->definitions->{lcfirst($defName)};
+                        if (isset($definition->properties) && is_object($definition->properties)) {
+                            $this->addNestedObject($defName, $definition->properties);
+                        }
+                    }
+                }
+
+                unset($constraints['$ref']);
             }
 
             $properties[] = [

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -40,6 +40,9 @@ final class HtmlRenderer
 {
     private string $alpsHtmlPath = 'alps.html';
 
+    /** @var array<string, string> Map of sanitized ID -> display name */
+    private array $knownObjects = [];
+
     /**
      * @param array<string, array<string, HtmlMethod>> $endpoints
      * @param array<string, HtmlObject>                $objects
@@ -237,7 +240,9 @@ HTML;
             return '';
         }
 
-        return sprintf('<a href="#%s" class="schema-link">%s</a>', htmlspecialchars($schemaName), htmlspecialchars($schemaName));
+        $sanitizedId = $this->sanitizeId($schemaName);
+
+        return sprintf('<a href="#%s" class="schema-link">%s</a>', htmlspecialchars($sanitizedId), htmlspecialchars($schemaName));
     }
 
     /** @param HtmlParam $param */
@@ -343,6 +348,13 @@ HTML;
      */
     private function renderObjectsAndArrays(array $objects, array $objectRelations): array
     {
+        // Collect known objects first (for relation linking)
+        $this->knownObjects = [];
+        foreach ($objects as $name => $object) {
+            $sanitizedId = $this->sanitizeId($name);
+            $this->knownObjects[$sanitizedId] = $name;
+        }
+
         $objectsHtml = '';
         $arraysHtml = '';
 
@@ -359,12 +371,14 @@ HTML;
 
     private function renderArrayType(string $name, string $itemType): string
     {
+        $sanitizedId = $this->sanitizeId($name);
         $escapedName = htmlspecialchars($name);
         $itemTypeCapitalized = ucfirst($itemType);
-        $itemLink = sprintf('<a href="#%s">%s</a>', htmlspecialchars($itemTypeCapitalized), htmlspecialchars($itemTypeCapitalized));
+        $itemTypeSanitized = $this->sanitizeId($itemTypeCapitalized);
+        $itemLink = sprintf('<a href="#%s">%s</a>', htmlspecialchars($itemTypeSanitized), htmlspecialchars($itemTypeCapitalized));
 
         return <<<HTML
-<div class="object-section" id="{$escapedName}">
+<div class="object-section" id="{$sanitizedId}">
 <h3 class="object-name">{$escapedName}</h3>
 <p class="array-type">array of {$itemLink}</p>
 </div>
@@ -378,6 +392,7 @@ HTML;
      */
     private function renderObject(string $name, array $object, array $objectRelations): string
     {
+        $sanitizedId = $this->sanitizeId($name);
         $escapedName = htmlspecialchars($name);
         $rows = '';
 
@@ -401,7 +416,7 @@ HTML;
         }
 
         return <<<HTML
-<div class="object-section" id="{$escapedName}">
+<div class="object-section" id="{$sanitizedId}">
 <h3 class="object-name">{$escapedName}</h3>
 <table>
 <thead>
@@ -422,7 +437,8 @@ HTML;
         $escapedName = htmlspecialchars($prop['name']);
         // If property has a ref, make the name a link to the object
         if ($prop['ref'] !== null) {
-            $nameHtml = sprintf('<a href="#%s" class="prop-name">%s</a>', htmlspecialchars($prop['ref']), $escapedName);
+            $sanitizedRef = $this->sanitizeId($prop['ref']);
+            $nameHtml = sprintf('<a href="#%s" class="prop-name">%s</a>', htmlspecialchars($sanitizedRef), $escapedName);
         } else {
             $nameHtml = sprintf('<span class="prop-name">%s</span>', $escapedName);
         }
@@ -494,7 +510,11 @@ HTML;
 HTML;
     }
 
-    /** @param HtmlRelation $relation */
+    /**
+     * @param HtmlRelation $relation
+     *
+     * @SuppressWarnings("PHPMD.NPathComplexity")
+     */
     private function renderRelationRow(array $relation, string $type): string
     {
         $rowClass = $type === 'embed' ? 'embed-row' : 'link-row';
@@ -505,25 +525,33 @@ HTML;
         $indicator = $transitionType !== '' ? sprintf('<span class="ti %s"></span>', $transitionType) : '';
         $hrefLabel = $type === 'embed' ? 'src' : 'href';
 
-        // Link to Object section - derive Object name from rel
+        // Try to link to Object section - derive Object name from rel
+        $relDisplay = $rel;
         $objectName = $relation['rel'];
+
         // Remove go/do prefix for links (e.g., goCard -> Card, doDelete -> Delete)
         if (preg_match('/^(go|do)([A-Z].*)$/', $objectName, $matches)) {
             $objectName = $matches[2];
             // Try singular form (e.g., Tickets -> Ticket)
             if (str_ends_with($objectName, 's') && strlen($objectName) > 1) {
                 $singular = rtrim($objectName, 's');
-                $objectName = $singular;
+                // Check if singular form exists first
+                if (isset($this->knownObjects[$singular])) {
+                    $objectName = $singular;
+                }
             }
         } else {
             $objectName = ucfirst($objectName);
         }
 
-        $relLink = sprintf('<a href="#%s">%s</a>', htmlspecialchars($objectName), $rel);
+        // Only create a link if the target object exists
+        if (isset($this->knownObjects[$objectName])) {
+            $relDisplay = sprintf('<a href="#%s">%s</a>', htmlspecialchars($objectName), $rel);
+        }
 
         return <<<HTML
 <tr class="{$rowClass}">
-  <td class="prop-name">{$indicator}{$relLink}</td>
+  <td class="prop-name">{$indicator}{$relDisplay}</td>
   <td><span class="badge {$type}">{$type}</span></td>
   <td class="param-desc">{$title}</td>
   <td>
@@ -556,6 +584,15 @@ HTML;
             'boolean' => 'bool',
             default => $type,
         };
+    }
+
+    /**
+     * Sanitize a name to be a valid HTML ID (remove spaces)
+     */
+    private function sanitizeId(string $name): string
+    {
+        // Remove spaces to create valid HTML ID (e.g., "Calendar Event" -> "CalendarEvent")
+        return (string) preg_replace('/\s+/', '', $name);
     }
 
     private function convertMarkdownLinks(string $text): string

--- a/src/HtmlRenderer.php
+++ b/src/HtmlRenderer.php
@@ -12,9 +12,14 @@ use function is_array;
 use function is_object;
 use function is_scalar;
 use function json_encode;
+use function ltrim;
+use function preg_match;
 use function preg_replace;
+use function rtrim;
 use function sprintf;
+use function str_ends_with;
 use function str_starts_with;
+use function strlen;
 use function ucfirst;
 
 use const JSON_UNESCAPED_SLASHES;
@@ -114,6 +119,7 @@ HTML;
   <th>Path</th>
   <th>Method</th>
   <th>Params</th>
+  <th>Type</th>
   <th>Description</th>
   <th>Meta</th>
   <th>Response</th>
@@ -139,7 +145,7 @@ HTML;
             $methodRowspan = $paramCount > 0 ? $paramCount : 1;
 
             if ($paramCount === 0) {
-                $pathCell = $isFirstPath ? sprintf('<td rowspan="%d" class="path-cell">%s</td>', $totalRows, htmlspecialchars($path)) : '';
+                $pathCell = $isFirstPath ? sprintf('<td rowspan="%d" class="path-cell" id="path-%s">%s</td>', $totalRows, htmlspecialchars(ltrim($path, '/')), htmlspecialchars($path)) : '';
                 $methodHtml = $this->renderMethodBadge($httpMethod, $data['summary'], $data['description'], $data['alps']);
                 $responseHtml = $this->renderResponseLink($data['response']);
 
@@ -165,7 +171,7 @@ HTML;
                 $responseCell = '';
 
                 if ($isFirstPath && $isFirstParam) {
-                    $pathCell = sprintf('<td rowspan="%d" class="path-cell">%s</td>', $totalRows, htmlspecialchars($path));
+                    $pathCell = sprintf('<td rowspan="%d" class="path-cell" id="path-%s">%s</td>', $totalRows, htmlspecialchars(ltrim($path, '/')), htmlspecialchars($path));
                 }
 
                 if ($isFirstParam) {
@@ -242,7 +248,8 @@ HTML;
             $nameHtml .= '<span class="req">*</span>';
         }
 
-        $metaHtml = $this->renderMetaBadges($param['type'], $param['constraints'], $param['example']);
+        $typeHtml = $this->renderTypeBadge($param['type']);
+        $metaHtml = $this->renderConstraintBadges($param['constraints'], $param['example']);
         $descriptionHtml = htmlspecialchars($param['description']);
 
         return <<<HTML
@@ -250,6 +257,7 @@ HTML;
   {$pathCell}
   {$methodCell}
   <td>{$nameHtml}</td>
+  <td>{$typeHtml}</td>
   <td class="param-desc">{$descriptionHtml}</td>
   <td>{$metaHtml}</td>
   {$responseCell}
@@ -275,14 +283,17 @@ HTML;
         );
     }
 
+    private function renderTypeBadge(string $type): string
+    {
+        $typeClass = 'type-' . $type;
+
+        return sprintf('<span class="badge %s">%s</span>', $typeClass, htmlspecialchars($type));
+    }
+
     /** @param array<string, mixed> $constraints */
-    private function renderMetaBadges(string $type, array $constraints, string $example = ''): string
+    private function renderConstraintBadges(array $constraints, string $example = ''): string
     {
         $badges = [];
-
-        // Type badge
-        $typeClass = 'type-' . $type;
-        $badges[] = sprintf('<span class="badge %s">%s</span>', $typeClass, htmlspecialchars($type));
 
         // Format badge (special case)
         if (isset($constraints['format'])) {
@@ -394,7 +405,7 @@ HTML;
 <h3 class="object-name">{$escapedName}</h3>
 <table>
 <thead>
-<tr><th>Name</th><th>Description</th><th>Meta</th></tr>
+<tr><th>Name</th><th>Type</th><th>Description</th><th>Meta</th></tr>
 </thead>
 <tbody>
 {$rows}
@@ -408,13 +419,22 @@ HTML;
     /** @param HtmlProperty $prop */
     private function renderPropertyRow(array $prop): string
     {
-        $nameHtml = sprintf('<span class="prop-name">%s</span>', htmlspecialchars($prop['name']));
+        $escapedName = htmlspecialchars($prop['name']);
+        // If property has a ref, make the name a link to the object
+        if ($prop['ref'] !== null) {
+            $nameHtml = sprintf('<a href="#%s" class="prop-name">%s</a>', htmlspecialchars($prop['ref']), $escapedName);
+        } else {
+            $nameHtml = sprintf('<span class="prop-name">%s</span>', $escapedName);
+        }
+
+        $typeHtml = $this->renderPropertyTypeBadge($prop);
         $metaHtml = $this->renderPropertyMeta($prop);
         $descriptionHtml = htmlspecialchars($prop['description']);
 
         return <<<HTML
 <tr>
   <td>{$nameHtml}</td>
+  <td>{$typeHtml}</td>
   <td class="param-desc">{$descriptionHtml}</td>
   <td>{$metaHtml}</td>
 </tr>
@@ -423,18 +443,18 @@ HTML;
     }
 
     /** @param HtmlProperty $prop */
+    private function renderPropertyTypeBadge(array $prop): string
+    {
+        $type = $this->normalizeType($prop['type']);
+        $typeClass = 'type-' . (preg_replace('/[^a-zA-Z0-9-]/', '', $type) ?? $type);
+
+        return sprintf('<span class="badge %s">%s</span>', $typeClass, htmlspecialchars($type));
+    }
+
+    /** @param HtmlProperty $prop */
     private function renderPropertyMeta(array $prop): string
     {
         $badges = [];
-
-        // Type badge (link to ref if available)
-        $type = $this->normalizeType($prop['type']);
-        $typeClass = 'type-' . (preg_replace('/[^a-zA-Z0-9-]/', '', $type) ?? $type);
-        if ($prop['ref'] !== null) {
-            $badges[] = sprintf('<a href="#%s" class="badge %s">%s</a>', htmlspecialchars($prop['ref']), $typeClass, htmlspecialchars($type));
-        } else {
-            $badges[] = sprintf('<span class="badge %s">%s</span>', $typeClass, htmlspecialchars($type));
-        }
 
         // Format badge
         if ($prop['format'] !== null) {
@@ -485,13 +505,29 @@ HTML;
         $indicator = $transitionType !== '' ? sprintf('<span class="ti %s"></span>', $transitionType) : '';
         $hrefLabel = $type === 'embed' ? 'src' : 'href';
 
+        // Link to Object section - derive Object name from rel
+        $objectName = $relation['rel'];
+        // Remove go/do prefix for links (e.g., goCard -> Card, doDelete -> Delete)
+        if (preg_match('/^(go|do)([A-Z].*)$/', $objectName, $matches)) {
+            $objectName = $matches[2];
+            // Try singular form (e.g., Tickets -> Ticket)
+            if (str_ends_with($objectName, 's') && strlen($objectName) > 1) {
+                $singular = rtrim($objectName, 's');
+                $objectName = $singular;
+            }
+        } else {
+            $objectName = ucfirst($objectName);
+        }
+
+        $relLink = sprintf('<a href="#%s">%s</a>', htmlspecialchars($objectName), $rel);
+
         return <<<HTML
 <tr class="{$rowClass}">
-  <td class="prop-name">{$indicator}{$rel}</td>
+  <td class="prop-name">{$indicator}{$relLink}</td>
+  <td><span class="badge {$type}">{$type}</span></td>
   <td class="param-desc">{$title}</td>
   <td>
     <div class="extra-info">
-      <span class="badge {$type}">{$type}</span>
       <span class="badge href">{$hrefLabel}: {$href}</span>
     </div>
   </td>


### PR DESCRIPTION
## Summary
- Add OpenAPI demo link to README
- Add dedicated Type column to Endpoints params table  
- Add dedicated Type column to Objects properties table
- Move embed/link type badges to Type column
- Make Name consistently clickable (not Type badge) for refs
- Link embed/link relations to their Object sections
- Add support for #/definitions/ JSON Schema references
- Add min-width to type badges for visual alignment

## Test plan
- [ ] Run `composer test`
- [ ] Run `composer docs` and visually verify the Type column in generated HTML
- [ ] Check that embed/link relations link correctly to Object sections