### PR TITLE
chore: upgrade to PHPUnit 11 and fix Codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "bear/aura-router-module": "^2.0.3",
         "bamarni/composer-bin-plugin": "^1.8.2",
         "koriym/attributes": "^1.0.5",
-        "phpunit/phpunit": "^9.6.15",
+        "phpunit/phpunit": "^11.0",
         "justinrainbow/json-schema": "^5.3 || ^6.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-  bootstrap="vendor/autoload.php">
-  <coverage cacheDirectory=".phpunit.cache/code-coverage"
-    processUncoveredFiles="true"
-    pathCoverage="true">
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
+  bootstrap="vendor/autoload.php"
+  cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="all">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>

--- a/tests/DocMethodTest.php
+++ b/tests/DocMethodTest.php
@@ -8,6 +8,7 @@ use ArrayObject;
 use BEAR\ApiDoc\Fake\Ro\FakeNoDoc;
 use BEAR\ApiDoc\Fake\Ro\FakeParamDoc;
 use FakeVendor\FakeProject\Resource\App\Person;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use SplFileInfo;
@@ -35,7 +36,7 @@ class DocMethodTest extends TestCase
         return $docMethod;
     }
 
-    /** @depends testPhpDocParamTag */
+    #[Depends('testPhpDocParamTag')]
     public function testToString(DocMethod $method): void
     {
         $this->assertStringContainsString('### Request', (string) $method);

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ApiDoc;
 
 use ArrayObject;
+use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
 use SplFileInfo;
 
@@ -30,7 +31,7 @@ class JsonSchemaTest extends TestCase
         return $jsonSchema;
     }
 
-    /** @depends testNewInstance */
+    #[Depends('testNewInstance')]
     public function testPropRequired(Schema $jsonSchema): void
     {
         $filePath = $jsonSchema->file->getPath() . '/' . $jsonSchema->file->getFilename();


### PR DESCRIPTION
## Summary

- Upgrade PHPUnit 9.6 -> 11.0
- Fix Codecov coverage collection (remove `pathCoverage="true"` incompatible with PCOV)
- Disable Codecov PR comments

## Changes

- **composer.json**: `phpunit/phpunit` ^9.6 -> ^11.0
- **phpunit.xml.dist**: PHPUnit 11 format (`<source>` element)
- **tests/*.php**: `@depends` -> `#[Depends]` attributes
- **codecov.yml**: `comment: false`