### PR TITLE
Support multiple output formats in single apidoc run

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ docs/
 │   └── *.json
 ├── openapi/
 │   ├── openapi.json    # OpenAPI spec
-│   └── index.html      # Redocly HTML
+│   └── index.html      # Redocly HTML (gh workflow only)
 └── alps/
     ├── alps.json       # ALPS profile
-    └── index.html      # ASD HTML
+    └── index.html      # ASD HTML (gh workflow only)
 ```
 
 ## Development

--- a/apidoc.xml.dist
+++ b/apidoc.xml.dist
@@ -5,8 +5,8 @@
     <appName>MyVendor/Package</appName>
     <scheme>app</scheme>
     <docDir>docs</docDir>
-    <!-- format: html | md | openapi | llms -->
-    <format>html</format>
+    <!-- format: html, md, openapi, llms (comma-separated for multiple) -->
+    <format>html,openapi,llms</format>
     <title>MyVendor/Package</title>
     <description>API Document</description>
     <alps>profile.json</alps>

--- a/apidoc.xsd
+++ b/apidoc.xsd
@@ -42,14 +42,11 @@
     </xs:element>
     <xs:element name="format">
         <xs:annotation>
-            <xs:documentation>Output document format</xs:documentation>
+            <xs:documentation>Output document format (comma-separated for multiple: html,llms)</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
             <xs:restriction base="xs:string">
-                <xs:enumeration value="html"/>
-                <xs:enumeration value="md"/>
-                <xs:enumeration value="openapi"/>
-                <xs:enumeration value="llms"/>
+                <xs:pattern value="(html|md|openapi|llms)(,(html|md|openapi|llms))*"/>
             </xs:restriction>
         </xs:simpleType>
     </xs:element>

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -29,7 +29,7 @@ use BEAR\ApiDoc\ConfigGenerator;
     }
 
     $options = getopt('c::', ['inline-css']);
-    $apidocXml = isset($options['c']) && is_string($options['c']) ? $options['c'] : '';
+    $apidocXml = isset($options['c']) && is_string($options['c']) ? $options['c'] : './apidoc.xml';
     $inlineCss = isset($options['inline-css']);
 
     try {

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -22,6 +22,7 @@ use function copy;
 use function dirname;
 use function file_exists;
 use function file_put_contents;
+use function implode;
 use function is_dir;
 use function is_object;
 use function is_string;
@@ -46,35 +47,38 @@ final readonly class ApiDoc
             $config->responseSchemaDir,
             new ModelRepository()
         );
-        $this->dump($config, $docClass);
 
-        $outputFile = match ($config->format) {
-            'openapi' => 'openapi.json',
-            'md' => 'index.md',
-            'llms' => 'llms.txt',
-            default => 'index.html',
-        };
+        $outputFiles = [];
+        foreach ($config->formats as $format) {
+            $this->dumpFormat($config, $docClass, $format);
+            $outputFiles[] = match ($format) {
+                'openapi' => 'openapi.json',
+                'md' => 'index.md',
+                'llms' => 'llms.txt',
+                default => 'index.html',
+            };
+        }
 
-        return sprintf('ApiDoc generated. %s/%s', (string) realpath($config->docDir), $outputFile);
+        return sprintf('ApiDoc generated. %s/%s', (string) realpath($config->docDir), implode(', ', $outputFiles));
     }
 
-    private function dump(Config $config, DocClass $docClass): void
+    private function dumpFormat(Config $config, DocClass $docClass, string $format): void
     {
         $this->mkDir($config->docDir);
 
-        if ($config->format === 'md') {
+        if ($format === 'md') {
             $this->dumpMd($config, $docClass);
 
             return;
         }
 
-        if ($config->format === 'openapi') {
+        if ($format === 'openapi') {
             $this->dumpOpenApi($config);
 
             return;
         }
 
-        if ($config->format === 'llms') {
+        if ($format === 'llms') {
             $this->dumpLlms($config);
 
             return;

--- a/src/Config.php
+++ b/src/Config.php
@@ -11,22 +11,25 @@ use Aura\Router\RouterContainer;
 use BEAR\ApiDoc\Exception\InvalidAppNamespaceException;
 use BEAR\AppMeta\Meta;
 use BEAR\AppMeta\ResMeta;
-use Generator;
 use Ray\Di\AbstractModule;
 use Ray\Di\Exception\Unbound;
 use Ray\Di\Injector;
 use Ray\Di\InjectorInterface;
 use SimpleXMLElement;
 
+use function array_map;
 use function assert;
 use function class_exists;
 use function dirname;
+use function explode;
 use function in_array;
 use function is_iterable;
 use function is_string;
+use function iterator_to_array;
 use function property_exists;
 use function realpath;
 use function sprintf;
+use function trim;
 
 final class Config
 {
@@ -39,7 +42,8 @@ final class Config
     /** @var non-empty-string */
     public readonly string $docDir;
 
-    public readonly string $format;
+    /** @var list<string> */
+    public readonly array $formats;
 
     public readonly string $title;
 
@@ -50,8 +54,8 @@ final class Config
 
     public string $alps = '';
 
-    /** @var Generator<ResMeta> */
-    public readonly Generator $resourceFiles;
+    /** @var array<ResMeta> */
+    public readonly array $resourceFiles;
 
     /** @var ArrayObject<string, string> */
     public readonly ArrayObject $modelRepository;
@@ -85,7 +89,8 @@ final class Config
         assert($appName !== '');
         $this->appName = $appName;
         $this->docDir = sprintf('%s/%s', $dir, (string) $xml->docDir);
-        $this->format = (string) $xml->format;
+        $formatString = (string) $xml->format;
+        $this->formats = array_map(trim(...), explode(',', $formatString));
         $scheme = (string) $xml->scheme;
         assert(in_array($scheme, ['*', 'app', 'page'], true));
         $this->scheme = $scheme;
@@ -125,7 +130,7 @@ final class Config
         $appModule = new $appModuleClass($meta, new AppMetaModule($meta));
         /** @psalm-suppress all */
         $injector = new Injector($appModule);
-        $this->resourceFiles = $meta->getGenerator($this->scheme);
+        $this->resourceFiles = iterator_to_array($meta->getGenerator($this->scheme));
 
         try {
             $jsonSchemaDir = $injector->getInstance('', 'json_schema_dir');

--- a/tests/ApiDocTest.php
+++ b/tests/ApiDocTest.php
@@ -107,4 +107,15 @@ class ApiDocTest extends TestCase
         $this->assertStringContainsString('## Routes', $content);
         $this->assertStringContainsString('## ResourceObjects', $content);
     }
+
+    public function testMultipleFormatsOutput(): void
+    {
+        $apiDoc = new ApiDoc();
+        $result = $apiDoc(__DIR__ . '/apidoc.multi.xml');
+
+        $this->assertStringContainsString('index.html', $result);
+        $this->assertStringContainsString('llms.txt', $result);
+        $this->assertFileExists(__DIR__ . '/docs/multi/index.html');
+        $this->assertFileExists(__DIR__ . '/docs/multi/llms.txt');
+    }
 }

--- a/tests/apidoc.multi.xml
+++ b/tests/apidoc.multi.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../apidoc.xsd">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>docs/multi</docDir>
+    <format>html,llms</format>
+    <title>FakeProject</title>
+    <description>A sample BEAR.Sunday application for testing</description>
+</apidoc>


### PR DESCRIPTION
## Summary
- Allow comma-separated format values in apidoc.xml (e.g., `<format>html,llms</format>`)
- Default to `./apidoc.xml` when `-c` option is not specified

## Changes
- Update XSD pattern to validate comma-separated formats
- Change `Config::$format` (string) to `Config::$formats` (array)
- Loop through formats in `ApiDoc::dumpFormat()`
- Convert Generator to array for multiple format iteration

## Usage
```xml
<format>html,llms</format>
```

```bash
# Uses ./apidoc.xml by default
./bin/apidoc

# Or specify config file
./bin/apidoc -c path/to/config.xml
```

Closes #71