### PR TITLE
Add ALPS semantic dictionary fallback for empty descriptions

### DIFF
--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -27,7 +27,7 @@ final class ConfigGenerator
 <?xml version="1.0" encoding="UTF-8"?>
 <apidoc
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/bear/apidoc/apidoc.xsd">
+        xsi:noNamespaceSchemaLocation="vendor/bear/api-doc/apidoc.xsd">
     <appName>%s</appName>
     <scheme>app</scheme>
     <docDir>docs</docDir>

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -286,15 +286,10 @@ final class HtmlGenerator
 
             $alpsTitle = $this->semanticDictionary[$paramName] ?? null;
 
-            // Use ALPS semantic dictionary as fallback for empty description
-            if ($description === '' && $alpsTitle !== null) {
-                $description = $alpsTitle;
-            }
-
             $params[] = [
                 'name' => $paramName,
                 'type' => $this->normalizeType($typeName),
-                'description' => $description,
+                'description' => $this->getDescriptionWithAlpsFallback($description, $paramName),
                 'required' => ! $param->isOptional(),
                 'example' => $example,
                 'constraints' => $constraints,
@@ -387,16 +382,10 @@ final class HtmlGenerator
                 unset($constraints['$ref']);
             }
 
-            // Use ALPS semantic dictionary as fallback for empty description
-            $description = $prop->description;
-            if ($description === '' && isset($this->semanticDictionary[$propName])) {
-                $description = $this->semanticDictionary[$propName];
-            }
-
             $properties[] = [
                 'name' => $propName,
                 'type' => $prop->type,
-                'description' => $description,
+                'description' => $this->getDescriptionWithAlpsFallback($prop->description, $propName),
                 'example' => $prop->example,
                 'format' => $format,
                 'constraints' => $constraints,
@@ -436,16 +425,12 @@ final class HtmlGenerator
             /** @psalm-suppress MixedAssignment */
             $format = $prop->format ?? null;
 
-            // Use ALPS semantic dictionary as fallback for empty description
             $descriptionStr = is_string($description) ? $description : '';
-            if ($descriptionStr === '' && isset($this->semanticDictionary[$propName])) {
-                $descriptionStr = $this->semanticDictionary[$propName];
-            }
 
             $properties[] = [
                 'name' => $propName,
                 'type' => is_string($type) ? $type : 'mixed',
-                'description' => $descriptionStr,
+                'description' => $this->getDescriptionWithAlpsFallback($descriptionStr, $propName),
                 'example' => is_string($example) || is_numeric($example) ? (string) $example : null,
                 'format' => is_string($format) ? $format : null,
                 'constraints' => [],
@@ -520,6 +505,18 @@ final class HtmlGenerator
     private function normalizeType(string $type): string
     {
         return $type;
+    }
+
+    /**
+     * Get description with ALPS semantic dictionary fallback
+     */
+    private function getDescriptionWithAlpsFallback(string $description, string $propName): string
+    {
+        if ($description !== '') {
+            return $description;
+        }
+
+        return $this->semanticDictionary[$propName] ?? '';
     }
 
     /** @return array<DocLink> */

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -286,6 +286,11 @@ final class HtmlGenerator
 
             $alpsTitle = $this->semanticDictionary[$paramName] ?? null;
 
+            // Use ALPS semantic dictionary as fallback for empty description
+            if ($description === '' && $alpsTitle !== null) {
+                $description = $alpsTitle;
+            }
+
             $params[] = [
                 'name' => $paramName,
                 'type' => $this->normalizeType($typeName),
@@ -382,10 +387,16 @@ final class HtmlGenerator
                 unset($constraints['$ref']);
             }
 
+            // Use ALPS semantic dictionary as fallback for empty description
+            $description = $prop->description;
+            if ($description === '' && isset($this->semanticDictionary[$propName])) {
+                $description = $this->semanticDictionary[$propName];
+            }
+
             $properties[] = [
                 'name' => $propName,
                 'type' => $prop->type,
-                'description' => $prop->description,
+                'description' => $description,
                 'example' => $prop->example,
                 'format' => $format,
                 'constraints' => $constraints,
@@ -425,10 +436,16 @@ final class HtmlGenerator
             /** @psalm-suppress MixedAssignment */
             $format = $prop->format ?? null;
 
+            // Use ALPS semantic dictionary as fallback for empty description
+            $descriptionStr = is_string($description) ? $description : '';
+            if ($descriptionStr === '' && isset($this->semanticDictionary[$propName])) {
+                $descriptionStr = $this->semanticDictionary[$propName];
+            }
+
             $properties[] = [
                 'name' => $propName,
                 'type' => is_string($type) ? $type : 'mixed',
-                'description' => is_string($description) ? $description : '',
+                'description' => $descriptionStr,
                 'example' => is_string($example) || is_numeric($example) ? (string) $example : null,
                 'format' => is_string($format) ? $format : null,
                 'constraints' => [],

--- a/tests/ApiDocTest.php
+++ b/tests/ApiDocTest.php
@@ -44,6 +44,31 @@ class ApiDocTest extends TestCase
         $this->assertStringContainsString('Person', $html);
     }
 
+    public function testAlpsDescriptionFallback(): void
+    {
+        $apiDoc = new ApiDoc();
+        $apiDoc(__DIR__ . '/apidoc.alps.xml');
+
+        $html = file_get_contents(__DIR__ . '/docs/html/index.html');
+        $this->assertIsString($html);
+
+        // Verify ALPS semantic dictionary is used as fallback for empty descriptions
+        // AlpsFallback resource has parameters without PHPDoc descriptions
+        // ALPS profile defines semantic information that should be used as fallback
+
+        // profile.json defines: firstName with title - shown in description column
+        $this->assertStringContainsString('<td class="param-desc">First Name by ALPS</td>', $html);
+
+        // profile.json defines: familyName with def - shown as link in description column
+        $this->assertStringContainsString('schema.org/familyName', $html);
+
+        // profile.json defines: age with doc - shown in description column
+        $this->assertStringContainsString('Age in years which must be equal to or greater than zero.', $html);
+
+        // profile.json defines: foo without title/doc/def - description should be empty
+        $this->assertMatchesRegularExpression('/<td><span class="param">foo<\/span>.*<td class="param-desc"><\/td>/s', $html);
+    }
+
     public function testOpenApiOutput(): void
     {
         $apiDoc = new ApiDoc();

--- a/tests/Fake/app/src/Resource/App/AlpsFallback.php
+++ b/tests/Fake/app/src/Resource/App/AlpsFallback.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\FakeProject\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+
+/**
+ * Resource to test ALPS semantic dictionary fallback for descriptions
+ */
+class AlpsFallback extends ResourceObject
+{
+    /**
+     * Test ALPS fallback - parameters have no PHPDoc description
+     */
+    public function onGet(
+        string $firstName,
+        string $familyName,
+        int $age,
+        string $foo,
+    ): static {
+        return $this;
+    }
+}


### PR DESCRIPTION
## Summary

- When description is empty, use ALPS semantic dictionary title as fallback for request parameters and response properties
- This allows API documentation to automatically display meaningful descriptions from ALPS profile when JSON Schema or PHPDoc descriptions are not provided

## Modified methods

- `buildParams`: Request parameters
- `addObject`: Response properties  
- `addNestedObject`: Nested response properties

## Example

Before: Parameters like `slug`, `dateCreated` showed empty description even when defined in ALPS profile.

After: If no description in JSON Schema or PHPDoc, the ALPS `title` attribute is used as fallback.

```xml
<descriptor id="slug" title="URLスラッグ" />
<descriptor id="dateCreated" title="作成日時" />
```

These titles now appear in the Description column of the generated API documentation.

## Test plan

- [x] All existing tests pass
- [x] PHPStan analysis passes
- [x] Psalm analysis passes

🤖 Generated with [Claude Code](https://claude.ai/code)