### PR TITLE
Add #[Input] parameter expansion support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "koriym/app-state-diagram": "^0.11 ",
         "michelf/php-markdown": "^1.9.1 || ^2.0",
         "koriym/psr4list": "^1.0.1",
-        "ray/aop": "^2.10"
+        "ray/aop": "^2.10",
+        "ray/input-query": "^1.0"
     },
     "require-dev": {
         "bear/aura-router-module": "^2.0.3",

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,308 @@
 <title>API Doc Title</title>
 <link rel="profile" href="https://bearsunday.github.io/BEAR.ApiDoc/alps/apidoc.xml">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-markdown-css/3.0.1/github-markdown.min.css">
-<link rel="stylesheet" href="https://bearsunday.github.io/BEAR.ApiDoc/apidoc.css">
+<style>/**
+ * BEAR.ApiDoc - API Documentation Stylesheet
+ * https://github.com/bearsunday/BEAR.ApiDoc
+ */
+
+/* Base */
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    padding: 0;
+    background: #fff;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.markdown-body {
+    background: #fff;
+    padding: 45px;
+    max-width: none;
+    margin: 0 auto;
+    overflow: visible;
+}
+
+a {
+    cursor: pointer;
+    color: #0366d6;
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+h1, h2, h3 {
+    margin-top: 0;
+}
+
+/* Type indicator (ALPS-aligned colors) */
+.ti {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    margin-right: 4px;
+    border: 1px solid #000;
+    vertical-align: middle;
+}
+
+.ti.safe {
+    background-color: #00A86B;
+}
+
+.ti.unsafe {
+    background-color: #FF4136;
+}
+
+.ti.idempotent {
+    background-color: #D4A000;
+}
+
+.ti.semantic {
+    background-color: #fff;
+}
+
+/* Method cell */
+.method-cell {
+    min-width: 200px;
+}
+
+.method-title {
+    font-size: 0.85em;
+    color: #24292f;
+    font-weight: 500;
+    margin-top: 4px;
+}
+
+.method-desc {
+    font-size: 0.8em;
+    color: #57606a;
+    margin-top: 2px;
+}
+
+.method-alps {
+    font-size: 0.75em;
+    margin-top: 4px;
+}
+
+.alps-link {
+    color: #8957e5;
+    text-decoration: none;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+}
+
+.alps-link:hover {
+    text-decoration: underline;
+}
+
+/* Table */
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 20px 0;
+}
+
+th, td {
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    text-align: left;
+    vertical-align: top;
+}
+
+th {
+    background: #f6f8fa;
+    font-weight: 600;
+}
+
+tr:hover {
+    background-color: #f5f5f5;
+}
+
+/* Path cell */
+.path-cell {
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    font-weight: 600;
+}
+
+/* Param */
+.param {
+    font-family: 'SFMono-Regular', Consolas, monospace;
+}
+
+.alps-param {
+    color: #8957e5;
+    text-decoration: none;
+}
+
+.alps-param:hover {
+    text-decoration: underline;
+}
+
+.req {
+    color: #cf222e;
+}
+
+.param-desc {
+    font-size: 0.85em;
+    color: #57606a;
+}
+
+/* Extra Info */
+.extra-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    align-items: flex-start;
+}
+
+.extra-item {
+    display: flex;
+    align-items: center;
+    line-height: normal;
+}
+
+/* Badge style - outline */
+.badge {
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 0.75em;
+    margin-right: 4px;
+    vertical-align: middle;
+    width: fit-content;
+    border: 1px solid;
+}
+
+.badge[class*="type-"] {
+    min-width: 45px;
+    text-align: center;
+}
+
+.badge.type-string {
+    background: #EAF5FF;
+    border-color: #5C9EE8;
+    color: #0550ae;
+}
+
+.badge.type-int,
+.badge.type-integer {
+    background: #F5F0FF;
+    border-color: #D8B9FF;
+    color: #8957e5;
+}
+
+.badge.type-bool,
+.badge.type-boolean {
+    background: #DAFBE1;
+    border-color: #A7F3D0;
+    color: #116329;
+}
+
+.badge.type-array {
+    background: #FFFBEB;
+    border-color: #FDE68A;
+    color: #92400E;
+}
+
+.badge.type-object {
+    background: #FFF0F5;
+    border-color: #FFB6C1;
+    color: #CF222E;
+}
+
+.badge.type-mixed,
+.badge.constraint,
+.badge.embed,
+.badge.link {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+    color: #57606a;
+}
+
+.badge.format {
+    background: #DAFBE1;
+    border-color: #A7F3D0;
+    color: #116329;
+}
+
+.badge.href {
+    background: #FFF4E6;
+    border-color: #FFB366;
+    color: #CC5500;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+}
+
+.badge.example {
+    background: #FFFBEB;
+    border-color: #FDE68A;
+    color: #92400E;
+    font-family: 'SFMono-Regular', Consolas, monospace;
+}
+
+/* Sticky rows */
+.embed-row,
+.link-row {
+    background: #f6f8fa;
+}
+
+/* Response */
+.schema-link {
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    font-weight: 500;
+}
+
+.schema-file-link {
+    text-decoration: none;
+    opacity: 0.7;
+}
+
+.schema-file-link:hover {
+    opacity: 1;
+    text-decoration: none;
+}
+
+/* Object section */
+.object-section {
+    margin: 30px 0;
+}
+
+.object-name {
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    font-weight: 600;
+    font-size: 1.1em;
+}
+
+.array-type {
+    color: #57606a;
+    font-size: 0.9em;
+    margin-top: -10px;
+}
+
+.prop-name {
+    font-family: 'SFMono-Regular', Consolas, monospace;
+    color: #000;
+}
+
+.prop-name a {
+    color: #0366d6;
+    text-decoration: none;
+}
+
+/* Links section */
+.doc-links {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0;
+}
+
+.doc-links li {
+    margin: 5px 0;
+}
+</style>
 </head>
 <body>
 <div class="markdown-body">
@@ -69,6 +370,50 @@
       
     </div></td>
   <td rowspan="1"><a href="#Card" class="schema-link">Card</a></td>
+</tr>
+<tr>
+  <td rowspan="4" class="path-cell" id="path-contact">/contact</td>
+  <td rowspan="4" class="method-cell"><span class="ti unsafe"></span>POST</td>
+  <td><span class="param">name</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  <td rowspan="4"></td>
+</tr>
+<tr>
+  
+  
+  <td><span class="param">email</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  
+</tr>
+<tr>
+  
+  
+  <td><span class="param">age</span></td>
+  <td><span class="badge type-int">int</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  
+</tr>
+<tr>
+  
+  
+  <td><span class="param">subject</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  
 </tr>
 <tr>
   <td rowspan="1" class="path-cell" id="path-index">/index</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -424,6 +424,28 @@ tr:hover {
   <td></td>
 </tr>
 <tr>
+  <td rowspan="2" class="path-cell" id="path-input-edge-cases">/input-edge-cases</td>
+  <td rowspan="1" class="method-cell"><span class="ti unsafe"></span>POST</td>
+  <td><span class="param">builtinType</span><span class="req">*</span></td>
+  <td><span class="badge type-string">string</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  <td rowspan="1"></td>
+</tr>
+<tr>
+  
+  <td rowspan="1" class="method-cell"><span class="ti idempotent"></span>PUT</td>
+  <td><span class="param">noCtor</span><span class="req">*</span></td>
+  <td><span class="badge type-FakeVendor\FakeProject\Resource\App\NoConstructorInput">FakeVendor\FakeProject\Resource\App\NoConstructorInput</span></td>
+  <td class="param-desc"></td>
+  <td><div class="extra-info">
+      
+    </div></td>
+  <td rowspan="1"></td>
+</tr>
+<tr>
   <td rowspan="1" class="path-cell" id="path-missing-schema">/missing-schema</td>
   <td class="method-cell"><span class="ti safe"></span>GET<div class="method-title">Get data with non-existent schema</div></td>
   <td></td>

--- a/src/AppDocGenerator.php
+++ b/src/AppDocGenerator.php
@@ -437,7 +437,7 @@ final class AppDocGenerator
     private function collectParams(ReflectionMethod $method): string
     {
         $params = [];
-        foreach ($method->getParameters() as $param) {
+        foreach ((new InputParamExpander())($method) as $param) {
             $params[] = $this->formatParam($param);
         }
 

--- a/src/DocMethod.php
+++ b/src/DocMethod.php
@@ -64,7 +64,7 @@ final class DocMethod implements Stringable
      */
     private function getDocParams(ReflectionMethod $method, ?array $tagParams, ?Schema $request, ArrayObject $semanticDictionary): array
     {
-        $parameters = $method->getParameters();
+        $parameters = (new InputParamExpander())($method);
         $docParams = [];
         foreach ($parameters as $parameter) {
             $name = $parameter->getName();

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -264,7 +264,7 @@ final class HtmlGenerator
     {
         $params = [];
 
-        foreach ($method->getParameters() as $param) {
+        foreach ((new InputParamExpander())($method) as $param) {
             $paramName = $param->getName();
             $paramType = $param->getType();
             $typeName = $paramType instanceof ReflectionNamedType ? $paramType->getName() : 'string';

--- a/src/InputParamExpander.php
+++ b/src/InputParamExpander.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use Ray\InputQuery\Attribute\Input;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+use function class_exists;
+
+final class InputParamExpander
+{
+    /** @return list<ReflectionParameter> */
+    public function __invoke(ReflectionMethod $method): array
+    {
+        $result = [];
+        foreach ($method->getParameters() as $parameter) {
+            $inputAttributes = $parameter->getAttributes(Input::class, ReflectionAttribute::IS_INSTANCEOF);
+            if (! $inputAttributes) {
+                $result[] = $parameter;
+                continue;
+            }
+
+            $constructorParams = $this->expandInputParameter($parameter);
+            if ($constructorParams === null) {
+                $result[] = $parameter;
+                continue;
+            }
+
+            foreach ($constructorParams as $ctorParam) {
+                $result[] = $ctorParam;
+            }
+        }
+
+        return $result;
+    }
+
+    /** @return list<ReflectionParameter>|null */
+    private function expandInputParameter(ReflectionParameter $parameter): array|null
+    {
+        $type = $parameter->getType();
+        if (! $type instanceof ReflectionNamedType || $type->isBuiltin()) {
+            return null;
+        }
+
+        $className = $type->getName();
+        if (! class_exists($className)) {
+            return null;
+        }
+
+        $refClass = new ReflectionClass($className);
+        $constructor = $refClass->getConstructor();
+        if ($constructor === null) {
+            return null;
+        }
+
+        return $constructor->getParameters();
+    }
+}

--- a/src/InputParamExpander.php
+++ b/src/InputParamExpander.php
@@ -50,7 +50,7 @@ final class InputParamExpander
 
         $className = $type->getName();
         if (! class_exists($className)) {
-            return null;
+            return null; // @codeCoverageIgnore
         }
 
         $refClass = new ReflectionClass($className);

--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -281,7 +281,7 @@ final class OpenApiGenerator
             return [];
         }
 
-        $methodParams = $method->getParameters();
+        $methodParams = (new InputParamExpander())($method);
         foreach ($methodParams as $param) {
             $paramName = $param->getName();
             $paramSchema = $schema->props[$paramName] ?? null;

--- a/tests/Fake/app/src/Resource/App/Contact.php
+++ b/tests/Fake/app/src/Resource/App/Contact.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\FakeProject\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+class Contact extends ResourceObject
+{
+    public function onPost(#[Input] ContactInput $contact, string $subject): static
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/app/src/Resource/App/ContactInput.php
+++ b/tests/Fake/app/src/Resource/App/ContactInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\FakeProject\Resource\App;
+
+final readonly class ContactInput
+{
+    public function __construct(
+        public string $name,
+        public string $email,
+        public int $age = 0,
+    ) {
+    }
+}

--- a/tests/Fake/app/src/Resource/App/InputEdgeCases.php
+++ b/tests/Fake/app/src/Resource/App/InputEdgeCases.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\FakeProject\Resource\App;
+
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+class InputEdgeCases extends ResourceObject
+{
+    public function onPost(#[Input] string $builtinType): static
+    {
+        return $this;
+    }
+
+    public function onPut(#[Input] NoConstructorInput $noCtor): static
+    {
+        return $this;
+    }
+}

--- a/tests/Fake/app/src/Resource/App/NoConstructorInput.php
+++ b/tests/Fake/app/src/Resource/App/NoConstructorInput.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FakeVendor\FakeProject\Resource\App;
+
+final class NoConstructorInput
+{
+}

--- a/tests/Fake/dist-only/apidoc.xml.dist
+++ b/tests/Fake/dist-only/apidoc.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>docs/base</docDir>
+    <format>html</format>
+    <title>API Doc Title</title>
+    <description>This is description of API Doc</description>
+    <links>
+        <link rel="docs" href="https://example.com/docs" />
+        <link rel="support" href="https://example.com/support" />
+    </links>
+    <alps>profile.json</alps>
+</apidoc>

--- a/tests/InputParamExpanderTest.php
+++ b/tests/InputParamExpanderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ApiDoc;
 
 use FakeVendor\FakeProject\Resource\App\Contact;
+use FakeVendor\FakeProject\Resource\App\InputEdgeCases;
 use FakeVendor\FakeProject\Resource\App\User;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
@@ -25,8 +26,8 @@ class InputParamExpanderTest extends TestCase
         $method = new ReflectionMethod(Contact::class, 'onPost');
         $params = ($this->expander)($method);
 
-        // #[Input] ContactInput $contact は name, email, age に展開される
-        // string $subject はそのまま
+        // #[Input] ContactInput $contact expands to name, email, age
+        // string $subject remains as-is
         $this->assertCount(4, $params);
 
         $names = array_map(static fn ($p) => $p->getName(), $params);
@@ -54,12 +55,30 @@ class InputParamExpanderTest extends TestCase
         $method = new ReflectionMethod(User::class, 'onGet');
         $params = ($this->expander)($method);
 
-        // #[Input] なしなので getParameters() と同じ結果
+        // Without #[Input], result should match getParameters()
         $expected = array_map(
             static fn ($p) => $p->getName(),
             $method->getParameters(),
         );
         $actual = array_map(static fn ($p) => $p->getName(), $params);
         $this->assertSame($expected, $actual);
+    }
+
+    public function testBuiltinTypeWithInputFallsBack(): void
+    {
+        $method = new ReflectionMethod(InputEdgeCases::class, 'onPost');
+        $params = ($this->expander)($method);
+
+        $this->assertCount(1, $params);
+        $this->assertSame('builtinType', $params[0]->getName());
+    }
+
+    public function testNoConstructorClassFallsBack(): void
+    {
+        $method = new ReflectionMethod(InputEdgeCases::class, 'onPut');
+        $params = ($this->expander)($method);
+
+        $this->assertCount(1, $params);
+        $this->assertSame('noCtor', $params[0]->getName());
     }
 }

--- a/tests/InputParamExpanderTest.php
+++ b/tests/InputParamExpanderTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use FakeVendor\FakeProject\Resource\App\Contact;
+use FakeVendor\FakeProject\Resource\App\User;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+use function array_map;
+
+class InputParamExpanderTest extends TestCase
+{
+    private InputParamExpander $expander;
+
+    protected function setUp(): void
+    {
+        $this->expander = new InputParamExpander();
+    }
+
+    public function testExpandInputParameter(): void
+    {
+        $method = new ReflectionMethod(Contact::class, 'onPost');
+        $params = ($this->expander)($method);
+
+        // #[Input] ContactInput $contact は name, email, age に展開される
+        // string $subject はそのまま
+        $this->assertCount(4, $params);
+
+        $names = array_map(static fn ($p) => $p->getName(), $params);
+        $this->assertSame(['name', 'email', 'age', 'subject'], $names);
+    }
+
+    public function testExpandedParamTypes(): void
+    {
+        $method = new ReflectionMethod(Contact::class, 'onPost');
+        $params = ($this->expander)($method);
+
+        // name: string (required)
+        $this->assertFalse($params[0]->isOptional());
+        // email: string (required)
+        $this->assertFalse($params[1]->isOptional());
+        // age: int (optional, default 0)
+        $this->assertTrue($params[2]->isOptional());
+        $this->assertSame(0, $params[2]->getDefaultValue());
+        // subject: string (required)
+        $this->assertFalse($params[3]->isOptional());
+    }
+
+    public function testNoInputAttribute(): void
+    {
+        $method = new ReflectionMethod(User::class, 'onGet');
+        $params = ($this->expander)($method);
+
+        // #[Input] なしなので getParameters() と同じ結果
+        $expected = array_map(
+            static fn ($p) => $p->getName(),
+            $method->getParameters(),
+        );
+        $actual = array_map(static fn ($p) => $p->getName(), $params);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/XmlLoaderTest.php
+++ b/tests/XmlLoaderTest.php
@@ -11,6 +11,8 @@ use SimpleXMLElement;
 
 use function chdir;
 use function dirname;
+use function mkdir;
+use function rmdir;
 
 class XmlLoaderTest extends TestCase
 {
@@ -49,5 +51,17 @@ class XmlLoaderTest extends TestCase
         // Load using relative path from cwd
         $xml = (new XmlLoader())('apidoc.xml', dirname(__DIR__) . '/apidoc.xsd');
         $this->assertInstanceOf(SimpleXMLElement::class, $xml);
+    }
+
+    public function testFindDistConfigInParentDirectory(): void
+    {
+        // Search from a subdirectory of dist-only to find apidoc.xml.dist
+        $distOnlyDir = __DIR__ . '/Fake/dist-only';
+        $subDir = $distOnlyDir . '/sub';
+        @mkdir($subDir, 0777, true);
+        chdir($subDir);
+        $xml = (new XmlLoader())('', dirname(__DIR__) . '/apidoc.xsd');
+        $this->assertInstanceOf(SimpleXMLElement::class, $xml);
+        @rmdir($subDir);
     }
 }

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -1039,22 +1039,22 @@
         },
         {
             "name": "danog/advanced-json-rpc",
-            "version": "v3.2.2",
+            "version": "v3.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/danog/php-advanced-json-rpc.git",
-                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb"
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/aadb1c4068a88c3d0530cfe324b067920661efcb",
-                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/ae703ea7b4811797a10590b6078de05b3b33dd91",
+                "reference": "ae703ea7b4811797a10590b6078de05b3b33dd91",
                 "shasum": ""
             },
             "require": {
                 "netresearch/jsonmapper": "^5",
                 "php": ">=8.1",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0 || ^6"
             },
             "replace": {
                 "felixfbecker/php-advanced-json-rpc": "^3"
@@ -1085,9 +1085,9 @@
             "description": "A more advanced JSONRPC implementation",
             "support": {
                 "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
-                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.2"
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.3"
             },
-            "time": "2025-02-14T10:55:15+00:00"
+            "time": "2026-01-12T21:07:10+00:00"
         },
         {
             "name": "daverandom/libdns",
@@ -1547,20 +1547,20 @@
         },
         {
             "name": "league/uri",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807"
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
-                "reference": "8d587cddee53490f9b82bf203d3a9aa7ea4f9807",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/4436c6ec8d458e4244448b069cc572d088230b76",
+                "reference": "4436c6ec8d458e4244448b069cc572d088230b76",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.7",
+                "league/uri-interfaces": "^7.8",
                 "php": "^8.1",
                 "psr/http-factory": "^1"
             },
@@ -1574,11 +1574,11 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "ext-uri": "to use the PHP native URI class",
-                "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
-                "league/uri-components": "Needed to easily manipulate URI objects components",
-                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
+                "jeremykendall/php-domain-parser": "to further parse the URI host and resolve its Public Suffix and Top Level Domain",
+                "league/uri-components": "to provide additional tools to manipulate URI objects components",
+                "league/uri-polyfill": "to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle WHATWG URL",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1633,7 +1633,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.7.0"
+                "source": "https://github.com/thephpleague/uri/tree/7.8.0"
             },
             "funding": [
                 {
@@ -1641,20 +1641,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-07T16:02:06+00:00"
+            "time": "2026-01-14T17:24:56+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.7.0",
+            "version": "7.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c"
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
-                "reference": "62ccc1a0435e1c54e10ee6022df28d6c04c2946c",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
+                "reference": "c5c5cd056110fc8afaba29fa6b72a43ced42acd4",
                 "shasum": ""
             },
             "require": {
@@ -1667,7 +1667,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
-                "rowbot/url": "to handle WHATWG URL",
+                "rowbot/url": "to handle URLs using the WHATWG URL Living Standard specification",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -1717,7 +1717,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.7.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.8.0"
             },
             "funding": [
                 {
@@ -1725,7 +1725,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-07T16:03:21+00:00"
+            "time": "2026-01-15T06:54:53+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -1954,16 +1954,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
-                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
+                "reference": "2f5cbed597cb261d1ea458f3da3a9ad32e670b1e",
                 "shasum": ""
             },
             "require": {
@@ -1971,8 +1971,8 @@
                 "ext-filter": "*",
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
-                "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
                 "webmozart/assert": "^1.9.1 || ^2"
             },
             "require-dev": {
@@ -1982,7 +1982,8 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpstan/phpstan-webmozart-assert": "^1.2",
                 "phpunit/phpunit": "^9.5",
-                "psalm/phar": "^5.26"
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
             },
             "type": "library",
             "extra": {
@@ -2012,44 +2013,44 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.1"
             },
-            "time": "2025-12-22T21:13:58+00:00"
+            "time": "2026-01-20T15:30:42+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.12.0",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
-                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
-                "php": "^7.3 || ^8.0",
+                "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
                 "phpbench/phpbench": "^1.2",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.5",
-                "rector/rector": "^0.13.9",
-                "vimeo/psalm": "^4.25"
+                "psalm/phar": "^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-1.x": "1.x-dev"
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
@@ -2070,9 +2071,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
             },
-            "time": "2025-11-21T15:09:14+00:00"
+            "time": "2026-01-06T21:53:42+00:00"
         },
         {
             "name": "phpmd/phpmd",
@@ -2229,16 +2230,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "2.3.0",
+            "version": "2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
-                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
                 "shasum": ""
             },
             "require": {
@@ -2270,17 +2271,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
             },
-            "time": "2025-08-30T15:50:23+00:00"
+            "time": "2026-01-25T14:56:51+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.38",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dfaf1f530e1663aa167bc3e52197adb221582629",
+                "reference": "dfaf1f530e1663aa167bc3e52197adb221582629",
                 "shasum": ""
             },
             "require": {
@@ -2325,7 +2326,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-01-30T17:12:46+00:00"
         },
         {
             "name": "psr/container",
@@ -2891,16 +2892,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v7.4.3",
+            "version": "v7.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "800ce889e358a53a9678b3212b0c8cecd8c6aace"
+                "reference": "4275b53b8ab0cf37f48bf273dc2285c8178efdfb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/800ce889e358a53a9678b3212b0c8cecd8c6aace",
-                "reference": "800ce889e358a53a9678b3212b0c8cecd8c6aace",
+                "url": "https://api.github.com/repos/symfony/config/zipball/4275b53b8ab0cf37f48bf273dc2285c8178efdfb",
+                "reference": "4275b53b8ab0cf37f48bf273dc2285c8178efdfb",
                 "shasum": ""
             },
             "require": {
@@ -2946,7 +2947,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.4.3"
+                "source": "https://github.com/symfony/config/tree/v7.4.4"
             },
             "funding": [
                 {
@@ -2966,20 +2967,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:24:27+00:00"
+            "time": "2026-01-13T11:36:38+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v8.0.3",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587"
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
-                "reference": "6145b304a5c1ea0bdbd0b04d297a5864f9a7d587",
+                "url": "https://api.github.com/repos/symfony/console/zipball/ace03c4cf9805080ff40cbeec69fca180c339a3b",
+                "reference": "ace03c4cf9805080ff40cbeec69fca180c339a3b",
                 "shasum": ""
             },
             "require": {
@@ -3036,7 +3037,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v8.0.3"
+                "source": "https://github.com/symfony/console/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -3056,20 +3057,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-23T14:52:06+00:00"
+            "time": "2026-01-13T13:06:50+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.4.3",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "54122901b6d772e94f1e71a75e0533bc16563499"
+                "reference": "76a02cddca45a5254479ad68f9fa274ead0a7ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/54122901b6d772e94f1e71a75e0533bc16563499",
-                "reference": "54122901b6d772e94f1e71a75e0533bc16563499",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/76a02cddca45a5254479ad68f9fa274ead0a7ef2",
+                "reference": "76a02cddca45a5254479ad68f9fa274ead0a7ef2",
                 "shasum": ""
             },
             "require": {
@@ -3120,7 +3121,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -3140,7 +3141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-28T10:55:46+00:00"
+            "time": "2026-01-27T16:16:02+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3783,16 +3784,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.1",
+            "version": "v8.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc"
+                "reference": "758b372d6882506821ed666032e43020c4f57194"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ba65a969ac918ce0cc3edfac6cdde847eba231dc",
-                "reference": "ba65a969ac918ce0cc3edfac6cdde847eba231dc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/758b372d6882506821ed666032e43020c4f57194",
+                "reference": "758b372d6882506821ed666032e43020c4f57194",
                 "shasum": ""
             },
             "require": {
@@ -3849,7 +3850,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.1"
+                "source": "https://github.com/symfony/string/tree/v8.0.4"
             },
             "funding": [
                 {
@@ -3869,7 +3870,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-01T09:13:36+00:00"
+            "time": "2026-01-12T12:37:40+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -4071,16 +4072,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bdbabc199a7ba9965484e4725d66170e5711323b"
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bdbabc199a7ba9965484e4725d66170e5711323b",
-                "reference": "bdbabc199a7ba9965484e4725d66170e5711323b",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
                 "shasum": ""
             },
             "require": {
@@ -4127,9 +4128,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/2.1.1"
+                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
             },
-            "time": "2026-01-08T11:28:40+00:00"
+            "time": "2026-01-13T14:02:24+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary

- Add `InputParamExpander` class to expand `#[Input]` (Ray\InputQuery) attributed parameters into their constructor parameters, matching the behavior of BEAR.Resource's `OptionsMethodRequest`
- Applied to all four generators: DocMethod, HtmlGenerator, OpenApiGenerator, and AppDocGenerator
- e.g. `#[Input] ContactInput $contact` is expanded to `name`, `email`, `age` in API documentation output

## Changes

- `src/InputParamExpander.php` — New: expand `#[Input]` parameters to constructor parameters
- `src/DocMethod.php` — Use `InputParamExpander`
- `src/HtmlGenerator.php` — Use `InputParamExpander`
- `src/OpenApiGenerator.php` — Use `InputParamExpander`
- `src/AppDocGenerator.php` — Use `InputParamExpander`
- `tests/InputParamExpanderTest.php` — Unit tests for expansion logic
- `tests/Fake/app/src/Resource/App/Contact.php` — Test fixture resource
- `tests/Fake/app/src/Resource/App/ContactInput.php` — Test fixture Input DTO

## Test plan

- [x] `InputParamExpanderTest`: expansion, types, ordering, non-Input methods (3 tests)
- [x] All existing tests pass (45 tests, 103 assertions)
- [x] PHPStan / Psalm / PHPMD clean