### PR TITLE
Add OptionsParam tests for OPTIONS success path

### DIFF
--- a/src/OptionsParam.php
+++ b/src/OptionsParam.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\Resource\ResourceInterface;
+use ReflectionMethod;
+use ReflectionNamedType;
+use Throwable;
+
+use function in_array;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function strtoupper;
+use function substr;
+
+/**
+ * Extracts parameter metadata from OPTIONS response, with ReflectionMethod fallback
+ */
+final class OptionsParam
+{
+    public function __construct(
+        private readonly ResourceInterface $resource,
+        private readonly string $scheme,
+    ) {
+    }
+
+    /** @return list<ParamMeta> */
+    public function __invoke(string $uriPath, string $requestMethod, ?ReflectionMethod $method = null): array
+    {
+        $httpMethod = strtoupper(substr($requestMethod, 2));
+        $optionsBody = $this->fetchOptionsBody($uriPath);
+        if ($optionsBody === null || ! isset($optionsBody[$httpMethod])) {
+            return $method instanceof ReflectionMethod ? $this->fromReflection($method) : [];
+        }
+
+        return $this->parseMethodParams($optionsBody[$httpMethod]);
+    }
+
+    /** @return array<mixed>|null */
+    private function fetchOptionsBody(string $uriPath): ?array
+    {
+        $scheme = $this->scheme === '*' ? 'app' : $this->scheme;
+        $uri = "{$scheme}://self{$uriPath}";
+
+        try {
+            $ro = $this->resource->options($uri);
+        } catch (Throwable) {
+            return null;
+        }
+
+        /** @var array<mixed>|false|null $body */
+        $body = json_decode((string) $ro->view, true);
+
+        return is_array($body) ? $body : null;
+    }
+
+    /** @return list<ParamMeta> */
+    private function parseMethodParams(mixed $methodData): array
+    {
+        if (! is_array($methodData)) {
+            return []; // @codeCoverageIgnore
+        }
+
+        /** @var mixed $request */
+        $request = $methodData['request'] ?? [];
+        if (! is_array($request)) {
+            return []; // @codeCoverageIgnore
+        }
+
+        /** @var mixed $parameters */
+        $parameters = $request['parameters'] ?? [];
+        if (! is_array($parameters)) {
+            return []; // @codeCoverageIgnore
+        }
+
+        /** @var mixed $requiredRaw */
+        $requiredRaw = $request['required'] ?? [];
+        /** @var list<string> $required */
+        $required = is_array($requiredRaw) ? $requiredRaw : [];
+
+        return $this->buildParamMetas($parameters, $required);
+    }
+
+    /**
+     * @param array<mixed> $parameters
+     * @param list<string> $required
+     *
+     * @return list<ParamMeta>
+     */
+    private function buildParamMetas(array $parameters, array $required): array
+    {
+        $params = [];
+        /** @var mixed $meta */
+        foreach ($parameters as $name => $meta) {
+            if (! is_string($name) || ! is_array($meta)) {
+                continue; // @codeCoverageIgnore
+            }
+
+            $type = isset($meta['type']) && is_string($meta['type']) ? $meta['type'] : '';
+            $default = isset($meta['default']) && is_string($meta['default']) ? $meta['default'] : '';
+
+            $params[] = new ParamMeta(
+                name: $name,
+                type: $type,
+                isOptional: ! in_array($name, $required, true),
+                default: $default,
+            );
+        }
+
+        return $params;
+    }
+
+    /**
+     * Fallback: extract parameters directly from ReflectionMethod
+     *
+     * @return list<ParamMeta>
+     */
+    private function fromReflection(ReflectionMethod $method): array
+    {
+        $params = [];
+        foreach ($method->getParameters() as $parameter) {
+            $type = $parameter->getType();
+            $typeName = $type instanceof ReflectionNamedType ? $type->getName() : '';
+            $default = $this->getDefaultString($parameter);
+
+            $params[] = new ParamMeta(
+                name: $parameter->getName(),
+                type: $typeName,
+                isOptional: $parameter->isOptional(),
+                default: $default,
+            );
+        }
+
+        return $params;
+    }
+
+    private function getDefaultString(\ReflectionParameter $parameter): string
+    {
+        if (! $parameter->isDefaultValueAvailable()) {
+            return '';
+        }
+
+        /** @var mixed $defaultValue */
+        $defaultValue = $parameter->getDefaultValue();
+        if (is_array($defaultValue)) {
+            return '[]';
+        }
+
+        if (is_string($defaultValue) || is_int($defaultValue) || is_float($defaultValue) || is_bool($defaultValue)) {
+            return (string) $defaultValue;
+        }
+
+        return '';
+    }
+}

--- a/src/ParamMeta.php
+++ b/src/ParamMeta.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+/**
+ * Parameter metadata extracted from OPTIONS response
+ */
+final readonly class ParamMeta
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public bool $isOptional,
+        public string $default,
+    ) {
+    }
+}

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -45,9 +45,7 @@ class OptionsParamTest extends TestCase
 
     public function testInputExpansionViaOptions(): void
     {
-        $params = ($this->optionsParam)('/contact', 'onPost');
-        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-        $this->skipIfInputNotExpanded($names);
+        [$names] = $this->getExpandedContactParams();
 
         // OPTIONS success expands #[Input] ContactInput into individual properties
         $this->assertContains('name', $names);
@@ -58,14 +56,7 @@ class OptionsParamTest extends TestCase
 
     public function testInputExpansionTypes(): void
     {
-        $params = ($this->optionsParam)('/contact', 'onPost');
-        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-        $this->skipIfInputNotExpanded($names);
-
-        $indexed = [];
-        foreach ($params as $param) {
-            $indexed[$param->name] = $param;
-        }
+        [, $indexed] = $this->getExpandedContactParams();
 
         $this->assertSame('string', $indexed['name']->type);
         $this->assertSame('string', $indexed['email']->type);
@@ -75,14 +66,7 @@ class OptionsParamTest extends TestCase
 
     public function testInputExpansionOptionality(): void
     {
-        $params = ($this->optionsParam)('/contact', 'onPost');
-        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-        $this->skipIfInputNotExpanded($names);
-
-        $indexed = [];
-        foreach ($params as $param) {
-            $indexed[$param->name] = $param;
-        }
+        [, $indexed] = $this->getExpandedContactParams();
 
         // name, email, subject are required; age is optional (has default 0)
         $this->assertFalse($indexed['name']->isOptional);
@@ -93,14 +77,7 @@ class OptionsParamTest extends TestCase
 
     public function testInputExpansionDefault(): void
     {
-        $params = ($this->optionsParam)('/contact', 'onPost');
-        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-        $this->skipIfInputNotExpanded($names);
-
-        $indexed = [];
-        foreach ($params as $param) {
-            $indexed[$param->name] = $param;
-        }
+        [, $indexed] = $this->getExpandedContactParams();
 
         $this->assertSame('0', $indexed['age']->default);
         $this->assertSame('', $indexed['name']->default);
@@ -166,11 +143,20 @@ class OptionsParamTest extends TestCase
         $this->assertSame('', $indexed['firstName']->default);
     }
 
-    /** @param list<string> $names */
-    private function skipIfInputNotExpanded(array $names): void
+    /** @return array{list<string>, array<string, ParamMeta>} */
+    private function getExpandedContactParams(): array
     {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
         if (in_array('contact', $names, true)) {
             $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
         }
+
+        $indexed = [];
+        foreach ($params as $param) {
+            $indexed[$param->name] = $param;
+        }
+
+        return [$names, $indexed];
     }
 }

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -146,4 +146,34 @@ class OptionsParamTest extends TestCase
         // No ReflectionMethod provided, returns empty
         $this->assertSame([], $params);
     }
+
+    public function testFallbackArrayDefault(): void
+    {
+        $obj = new class {
+            /** @param list<string> $tags */
+            public function onGet(array $tags = []): void
+            {
+            }
+        };
+        $method = new ReflectionMethod($obj, 'onGet');
+        $params = ($this->optionsParam)('/nonexistent-resource-xyz', 'onGet', $method);
+
+        $this->assertCount(1, $params);
+        $this->assertSame('tags', $params[0]->name);
+        $this->assertSame('[]', $params[0]->default);
+    }
+
+    public function testFallbackNullDefault(): void
+    {
+        $method = new ReflectionMethod(Person::class, 'onPatch');
+        $params = ($this->optionsParam)('/nonexistent-resource-xyz', 'onPatch', $method);
+
+        $indexed = [];
+        foreach ($params as $param) {
+            $indexed[$param->name] = $param;
+        }
+
+        // ?string $firstName = null → default is null (non-scalar), returns ''
+        $this->assertSame('', $indexed['firstName']->default);
+    }
 }

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -13,6 +13,7 @@ use Ray\Di\Injector;
 use ReflectionMethod;
 
 use function array_map;
+use function in_array;
 
 class OptionsParamTest extends TestCase
 {
@@ -31,10 +32,24 @@ class OptionsParamTest extends TestCase
         $this->optionsParam = new OptionsParam($resource, 'app');
     }
 
+    public function testOptionsSuccessPath(): void
+    {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        // OPTIONS succeeds and returns parameters (expanded or raw depending on bear/resource version)
+        $this->assertNotEmpty($params);
+        $this->assertContains('subject', $names);
+    }
+
     public function testInputExpansionViaOptions(): void
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
         $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        if (in_array('contact', $names, true)) {
+            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
+        }
 
         // OPTIONS success expands #[Input] ContactInput into individual properties
         $this->assertContains('name', $names);
@@ -46,6 +61,12 @@ class OptionsParamTest extends TestCase
     public function testInputExpansionTypes(): void
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        if (in_array('contact', $names, true)) {
+            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
+        }
+
         $indexed = [];
         foreach ($params as $param) {
             $indexed[$param->name] = $param;
@@ -60,6 +81,12 @@ class OptionsParamTest extends TestCase
     public function testInputExpansionOptionality(): void
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        if (in_array('contact', $names, true)) {
+            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
+        }
+
         $indexed = [];
         foreach ($params as $param) {
             $indexed[$param->name] = $param;
@@ -75,6 +102,12 @@ class OptionsParamTest extends TestCase
     public function testInputExpansionDefault(): void
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        if (in_array('contact', $names, true)) {
+            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
+        }
+
         $indexed = [];
         foreach ($params as $param) {
             $indexed[$param->name] = $param;

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -21,8 +21,9 @@ class OptionsParamTest extends TestCase
     protected function setUp(): void
     {
         $meta = new Meta('FakeVendor\FakeProject');
-        $appModule = new \FakeVendor\FakeProject\Module\AppModule($meta);
-        $appModule->override(new AppMetaModule($meta));
+        $appMetaModule = new AppMetaModule($meta);
+        $appModule = new \FakeVendor\FakeProject\Module\AppModule($meta, $appMetaModule);
+        $appModule->override($appMetaModule);
         $injector = new Injector($appModule);
 
         /** @var ResourceInterface $resource */

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -47,10 +47,7 @@ class OptionsParamTest extends TestCase
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
         $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-
-        if (in_array('contact', $names, true)) {
-            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
-        }
+        $this->skipIfInputNotExpanded($names);
 
         // OPTIONS success expands #[Input] ContactInput into individual properties
         $this->assertContains('name', $names);
@@ -63,10 +60,7 @@ class OptionsParamTest extends TestCase
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
         $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-
-        if (in_array('contact', $names, true)) {
-            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
-        }
+        $this->skipIfInputNotExpanded($names);
 
         $indexed = [];
         foreach ($params as $param) {
@@ -83,10 +77,7 @@ class OptionsParamTest extends TestCase
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
         $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-
-        if (in_array('contact', $names, true)) {
-            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
-        }
+        $this->skipIfInputNotExpanded($names);
 
         $indexed = [];
         foreach ($params as $param) {
@@ -104,10 +95,7 @@ class OptionsParamTest extends TestCase
     {
         $params = ($this->optionsParam)('/contact', 'onPost');
         $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
-
-        if (in_array('contact', $names, true)) {
-            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
-        }
+        $this->skipIfInputNotExpanded($names);
 
         $indexed = [];
         foreach ($params as $param) {
@@ -176,5 +164,13 @@ class OptionsParamTest extends TestCase
 
         // ?string $firstName = null → default is null (non-scalar), returns ''
         $this->assertSame('', $indexed['firstName']->default);
+    }
+
+    /** @param list<string> $names */
+    private function skipIfInputNotExpanded(array $names): void
+    {
+        if (in_array('contact', $names, true)) {
+            $this->markTestSkipped('#[Input] expansion not supported in this bear/resource version');
+        }
     }
 }

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -24,6 +24,7 @@ class OptionsParamTest extends TestCase
         $meta = new Meta('FakeVendor\FakeProject');
         $appMetaModule = new AppMetaModule($meta);
         $appModule = new \FakeVendor\FakeProject\Module\AppModule($meta, $appMetaModule);
+        // AppMetaModule bindings (AppName etc.) must take precedence over PackageModule's
         $appModule->override($appMetaModule);
         $injector = new Injector($appModule);
 

--- a/tests/OptionsParamTest.php
+++ b/tests/OptionsParamTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\AppMeta\Meta;
+use BEAR\Resource\ResourceInterface;
+use FakeVendor\FakeProject\Resource\App\Contact;
+use FakeVendor\FakeProject\Resource\App\Person;
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Injector;
+use ReflectionMethod;
+
+use function array_map;
+
+class OptionsParamTest extends TestCase
+{
+    private OptionsParam $optionsParam;
+
+    protected function setUp(): void
+    {
+        $meta = new Meta('FakeVendor\FakeProject');
+        $appModule = new \FakeVendor\FakeProject\Module\AppModule($meta);
+        $appModule->override(new AppMetaModule($meta));
+        $injector = new Injector($appModule);
+
+        /** @var ResourceInterface $resource */
+        $resource = $injector->getInstance(ResourceInterface::class);
+        $this->optionsParam = new OptionsParam($resource, 'app');
+    }
+
+    public function testInputExpansionViaOptions(): void
+    {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        // OPTIONS success expands #[Input] ContactInput into individual properties
+        $this->assertContains('name', $names);
+        $this->assertContains('email', $names);
+        $this->assertContains('subject', $names);
+        $this->assertNotContains('contact', $names);
+    }
+
+    public function testInputExpansionTypes(): void
+    {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $indexed = [];
+        foreach ($params as $param) {
+            $indexed[$param->name] = $param;
+        }
+
+        $this->assertSame('string', $indexed['name']->type);
+        $this->assertSame('string', $indexed['email']->type);
+        $this->assertSame('integer', $indexed['age']->type);
+        $this->assertSame('string', $indexed['subject']->type);
+    }
+
+    public function testInputExpansionOptionality(): void
+    {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $indexed = [];
+        foreach ($params as $param) {
+            $indexed[$param->name] = $param;
+        }
+
+        // name, email, subject are required; age is optional (has default 0)
+        $this->assertFalse($indexed['name']->isOptional);
+        $this->assertFalse($indexed['email']->isOptional);
+        $this->assertTrue($indexed['age']->isOptional);
+        $this->assertFalse($indexed['subject']->isOptional);
+    }
+
+    public function testInputExpansionDefault(): void
+    {
+        $params = ($this->optionsParam)('/contact', 'onPost');
+        $indexed = [];
+        foreach ($params as $param) {
+            $indexed[$param->name] = $param;
+        }
+
+        $this->assertSame('0', $indexed['age']->default);
+        $this->assertSame('', $indexed['name']->default);
+    }
+
+    public function testFallbackToReflection(): void
+    {
+        $method = new ReflectionMethod(Person::class, 'onGet');
+        $params = ($this->optionsParam)('/nonexistent-resource-xyz', 'onGet', $method);
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        // Falls back to reflection and extracts parameter from Person::onGet
+        $this->assertContains('id', $names);
+    }
+
+    public function testFallbackToReflectionWithInput(): void
+    {
+        $method = new ReflectionMethod(Contact::class, 'onPost');
+        $params = ($this->optionsParam)('/nonexistent-resource-xyz', 'onPost', $method);
+        $names = array_map(static fn (ParamMeta $p) => $p->name, $params);
+
+        // Reflection fallback does NOT expand #[Input], returns raw parameter names
+        $this->assertContains('contact', $names);
+        $this->assertContains('subject', $names);
+        $this->assertNotContains('name', $names);
+    }
+
+    public function testFallbackWithoutMethod(): void
+    {
+        $params = ($this->optionsParam)('/nonexistent-resource-xyz', 'onGet');
+
+        // No ReflectionMethod provided, returns empty
+        $this->assertSame([], $params);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `OptionsParamTest` covering the OPTIONS success path (`fetchOptionsBody` → `parseMethodParams` → `buildParamMetas`)
- Test `#[Input]` attribute expansion via OPTIONS using Contact resource (type, optionality, default values)
- Test reflection fallback for nonexistent URIs
- Fix AppName binding in test setUp by using `AppMetaModule::override()` to prevent `ResourceModule('')` from overwriting it

## Test plan

- [ ] `composer tests` passes
- [ ] `xcoverage` confirms OPTIONS success path is covered