### PR TITLE
Allow phpdocumentor/reflection-docblock ^5.2 || ^6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-simplexml": "*",
         "ext-libxml": "*",
         "ext-dom": "*",
-        "phpdocumentor/reflection-docblock": "^6.0",
+        "phpdocumentor/reflection-docblock": "^5.2 || ^6.0",
         "bear/resource": "^1.16.2",
         "bear/sunday": "^1.4",
         "bear/app-meta": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "ext-simplexml": "*",
         "ext-libxml": "*",
         "ext-dom": "*",
-        "phpdocumentor/reflection-docblock": "^4.3 || ^5.2",
+        "phpdocumentor/reflection-docblock": "^6.0",
         "bear/resource": "^1.16.2",
         "bear/sunday": "^1.4",
         "bear/app-meta": "^1.7",


### PR DESCRIPTION
## Summary

Allow `phpdocumentor/reflection-docblock` 6.x in addition to the existing 5.x range so bear/api-doc can resolve alongside [bear/resource 1.31.1](https://github.com/bearsunday/BEAR.Resource/releases/tag/1.31.1) (`JsonSchemaInterceptor` support for `#[Input]` DTO methods, [bearsunday/BEAR.Resource#356](https://github.com/bearsunday/BEAR.Resource/issues/356), requires phpdoc `^6.0`).

4.x is dropped because phpdoc 4 stopped at PHP 8.0 and bear/api-doc already requires PHP `^8.2`. 5.x is retained so `--prefer-lowest` keeps resolving the existing `bear/resource ^1.16.2` baseline (1.22.3) — narrowing to `^6.0` only would bump that lowest to 1.30.0 and surface an unrelated Doctrine-annotations regression.

No code changes are required — existing `DocBlockFactory::createInstance()` / `DocBlock\*` usages are stable across 5.x and 6.x.

## Verification

Against `phpdocumentor/reflection-docblock 6.0.3` + `bear/resource 1.31.1`:

- `composer test` — 64/64 (154 assertions)
- `composer cs`
- `phpstan` — No errors
- `psalm` — No errors

## Test plan

- [ ] CI green on `1.x` (highest + lowest)
- [ ] Tag a patch release once merged