### PR TITLE
Harden documentation generation failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Emit OpenAPI request inputs for `#[Input]` DTO methods without requiring `#[JsonSchema(params: ...)]` (#81)
+- Fix `composer setup` to call the existing `apidoc init` command instead of a missing setup script (#86)
+- Surface invalid JSON, XML loading, and output write failures during documentation generation (#86)
 
 ### Changed
 - Allow `phpdocumentor/reflection-docblock` `^6.0` while keeping `^5.2` compatibility (#82)

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     },
     "bin": ["bin/apidoc"],
     "scripts": {
-        "setup": "php bin/setup.php",
+        "setup": "php bin/apidoc init",
         "test": "./vendor/bin/phpunit",
         "coverage": "php -dzend_extension=xdebug.so -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage",
         "pcov": "php -dextension=pcov.so -d pcov.enabled=1 ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage  --coverage-clover=coverage.xml",
@@ -63,9 +63,9 @@
             "./vendor/bin/psalm --clear-cache"
         ],
         "sa": [
-            "./vendor/bin/phpstan analyse -c phpstan.neon",
+            "./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G",
             "./vendor/bin/psalm --show-info=true",
-            "./vendor/bin/phpmd src text phpmd.xml"
+            "php -d error_reporting=24575 ./vendor/bin/phpmd src text phpmd.xml"
         ],
         "tests": [
             "@cs",

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -144,7 +144,10 @@ final readonly class ApiDoc
         }
 
         // @codeCoverageIgnoreStart
-        mkdir($dir, 0777, true);
+        if (! mkdir($dir, 0777, true) && ! is_dir($dir)) {
+            throw new NotWritableException($dir);
+        }
+
         chmod(dirname($dir), 0777);
         chmod($dir, 0777);
         // @codeCoverageIgnoreEnd
@@ -178,7 +181,7 @@ final readonly class ApiDoc
     private function copySchemas(Config $config): void
     {
         $outputDir = sprintf('%s/schemas', $config->docDir);
-        if (! is_dir($outputDir) && ! mkdir($outputDir)) {
+        if (! is_dir($outputDir) && ! mkdir($outputDir, 0777, true) && ! is_dir($outputDir)) {
             // @codeCoverageIgnoreStart
             throw new NotWritableException($outputDir);
             // @codeCoverageIgnoreEnd
@@ -188,7 +191,7 @@ final readonly class ApiDoc
 
         // Generate schema index
         $indexHtml = (string) new SchemaIndex($outputDir);
-        file_put_contents($outputDir . '/index.html', $indexHtml);
+        $this->filePutContents($outputDir . '/index.html', $indexHtml);
     }
 
     /** @return ArrayObject<string, string> */
@@ -245,7 +248,12 @@ final readonly class ApiDoc
             return;
         }
 
-        copy($path, $destination);
+        // @codeCoverageIgnoreStart
+        if (! copy($path, $destination)) {
+            throw new NotWritableException($destination);
+        }
+
+        // @codeCoverageIgnoreEnd
     }
 
     private function dumpOpenApi(Config $config): void

--- a/src/AppDocGenerator.php
+++ b/src/AppDocGenerator.php
@@ -23,7 +23,6 @@ use function interface_exists;
 use function is_array;
 use function is_dir;
 use function is_string;
-use function json_decode;
 use function pathinfo;
 use function preg_match;
 use function preg_match_all;
@@ -58,9 +57,13 @@ final class AppDocGenerator
 
     private string $appDir = '';
 
+    private readonly JsonFile $jsonFile;
+
     public function __construct(
         private readonly Config $config,
+        ?JsonFile $jsonFile = null,
     ) {
+        $this->jsonFile = $jsonFile ?? new JsonFile();
     }
 
     public function generate(): string
@@ -140,15 +143,7 @@ final class AppDocGenerator
     /** @codeCoverageIgnore Response schema parsing depends on runtime schema availability */
     private function parseJsonSchemaProperties(string $schemaFile): string
     {
-        $content = file_get_contents($schemaFile);
-        if ($content === false) {
-            return '';
-        }
-
-        $schema = json_decode($content, true);
-        if (! is_array($schema)) {
-            return '';
-        }
+        $schema = $this->jsonFile->assoc($schemaFile);
 
         // Handle array type
         if (isset($schema['type']) && $schema['type'] === 'array') {

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -6,6 +6,8 @@ namespace BEAR\ApiDoc;
 
 use BEAR\ApiDoc\Exception\ComposerJsonNotFoundException;
 use BEAR\ApiDoc\Exception\InvalidComposerJsonException;
+use BEAR\ApiDoc\Exception\NotWritableException;
+use JsonException;
 
 use function array_key_first;
 use function count;
@@ -15,10 +17,17 @@ use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
 use function getcwd;
+use function htmlspecialchars;
 use function is_array;
+use function is_string;
 use function json_decode;
 use function rtrim;
 use function sprintf;
+
+use const ENT_QUOTES;
+use const ENT_SUBSTITUTE;
+use const ENT_XML1;
+use const JSON_THROW_ON_ERROR;
 
 /** @codeCoverageIgnore */
 final class ConfigGenerator
@@ -48,16 +57,23 @@ XML;
         $composerInfo = $this->parseComposerJson($composerJsonPath);
         $projectName = $this->getProjectName($composerInfo['appName']);
         $descriptionElement = $composerInfo['description'] !== ''
-            ? sprintf("\n    <description>%s</description>", $composerInfo['description'])
+            ? sprintf("\n    <description>%s</description>", $this->escapeXml($composerInfo['description']))
             : '';
-        $xml = sprintf(self::TEMPLATE, $composerInfo['appName'], $projectName, $descriptionElement);
+        $xml = sprintf(
+            self::TEMPLATE,
+            $this->escapeXml($composerInfo['appName']),
+            $this->escapeXml($projectName),
+            $descriptionElement,
+        );
 
         $outputPath = dirname($composerJsonPath) . '/' . self::OUTPUT_FILE;
         if (file_exists($outputPath)) {
             return sprintf('ApiDoc config already exists: %s', $outputPath);
         }
 
-        file_put_contents($outputPath, $xml);
+        if (file_put_contents($outputPath, $xml) === false) {
+            throw new NotWritableException($outputPath);
+        }
 
         return sprintf('ApiDoc config created: %s', $outputPath);
     }
@@ -85,8 +101,13 @@ XML;
             throw new InvalidComposerJsonException('Cannot read composer.json');
         }
 
-        /** @var array{autoload?: array{psr-4?: array<string, string>}, description?: string}|null $json */
-        $json = json_decode($content, true);
+        try {
+            /** @var array{autoload?: array{psr-4?: array<string, string>}, description?: mixed}|null $json */
+            $json = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidComposerJsonException($e->getMessage(), 0, $e);
+        }
+
         if (! is_array($json)) {
             throw new InvalidComposerJsonException('Invalid composer.json format');
         }
@@ -97,7 +118,7 @@ XML;
         }
 
         $namespace = array_key_first($psr4);
-        $description = $json['description'] ?? '';
+        $description = isset($json['description']) && is_string($json['description']) ? $json['description'] : '';
 
         return [
             'appName' => rtrim($namespace, '\\'),
@@ -113,5 +134,10 @@ XML;
         $parts = explode('\\', $appName);
 
         return $parts[count($parts) - 1];
+    }
+
+    private function escapeXml(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/DocClass.php
+++ b/src/DocClass.php
@@ -11,13 +11,9 @@ use ReflectionClass;
 use ReflectionMethod;
 use SplFileInfo;
 
-use function assert;
-use function file_get_contents;
 use function implode;
 use function in_array;
 use function is_file;
-use function is_object;
-use function json_decode;
 use function sprintf;
 
 use const PHP_EOL;
@@ -27,14 +23,18 @@ final class DocClass
     /** @var ArrayObject<string, string> */
     private $semanticDictionary;
 
+    private readonly JsonFile $jsonFile;
+
     public function __construct(
         private readonly string $requestSchemaDir,
         private readonly string $responseSchemaDir,
-        public ModelRepository $modelRepository
+        public ModelRepository $modelRepository,
+        ?JsonFile $jsonFile = null,
     ) {
         /** @var ArrayObject<string, string> $nullDictinary */
         $nullDictinary = new ArrayObject();
         $this->semanticDictionary = $nullDictinary;
+        $this->jsonFile = $jsonFile ?? new JsonFile();
     }
 
     /**
@@ -133,10 +133,8 @@ EOT;
             return null;
         }
 
-        $schemaJson = json_decode((string) file_get_contents($schemaFile));
-        assert(is_object($schemaJson));
         $fileInfo = new SplFileInfo($schemaFile);
 
-        return new Schema($fileInfo, $schemaJson, $this->semanticDictionary);
+        return new Schema($fileInfo, $this->jsonFile->object($schemaFile), $this->semanticDictionary);
     }
 }

--- a/src/Exception/InvalidJsonFileException.php
+++ b/src/Exception/InvalidJsonFileException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc\Exception;
+
+use RuntimeException;
+
+final class InvalidJsonFileException extends RuntimeException
+{
+}

--- a/src/HtmlGenerator.php
+++ b/src/HtmlGenerator.php
@@ -22,7 +22,6 @@ use function is_file;
 use function is_numeric;
 use function is_object;
 use function is_string;
-use function json_decode;
 use function lcfirst;
 use function pathinfo;
 use function sprintf;
@@ -59,6 +58,8 @@ final class HtmlGenerator
     /** @var ArrayObject<string, string> */
     private readonly ArrayObject $semanticDictionary;
 
+    private readonly JsonFile $jsonFile;
+
     /**
      * @param ArrayObject<string, string>|null $semanticDictionary
      *
@@ -70,11 +71,13 @@ final class HtmlGenerator
         private readonly string $responseSchemaDir,
         ?ArrayObject $semanticDictionary = null,
         private readonly bool $inlineCss = false,
+        ?JsonFile $jsonFile = null,
     ) {
         $this->renderer = new HtmlRenderer();
         /** @var ArrayObject<string, string> $emptyDictionary */
         $emptyDictionary = new ArrayObject();
         $this->semanticDictionary = $semanticDictionary ?? $emptyDictionary;
+        $this->jsonFile = $jsonFile ?? new JsonFile();
     }
 
     public function generate(): string
@@ -307,16 +310,11 @@ final class HtmlGenerator
             return null;
         }
 
-        $schemaJson = json_decode((string) file_get_contents($schemaFile));
-        if (! is_object($schemaJson)) {
-            return null; // @codeCoverageIgnore
-        }
-
         $fileInfo = new SplFileInfo($schemaFile);
         /** @var ArrayObject<string, string> $emptyDictionary */
         $emptyDictionary = new ArrayObject();
 
-        return new Schema($fileInfo, $schemaJson, $emptyDictionary);
+        return new Schema($fileInfo, $this->jsonFile->object($schemaFile), $emptyDictionary);
     }
 
     /** @SuppressWarnings("PHPMD.NPathComplexity") */
@@ -334,8 +332,7 @@ final class HtmlGenerator
         }
 
         // Load raw schema to access definitions
-        /** @psalm-suppress MixedAssignment */
-        $schemaJson = json_decode((string) file_get_contents($schema->file->getPathname()));
+        $schemaJson = $this->jsonFile->object($schema->file->getPathname());
 
         foreach ($schema->props as $propName => $prop) {
             if ($propName === '_links') {
@@ -369,7 +366,7 @@ final class HtmlGenerator
                     $ref = $defName;
                     // Add the definition as an Object if it exists
                     /** @psalm-suppress MixedPropertyFetch */
-                    if (is_object($schemaJson) && isset($schemaJson->definitions->{lcfirst($defName)}) && is_object($schemaJson->definitions->{lcfirst($defName)})) {
+                    if (isset($schemaJson->definitions->{lcfirst($defName)}) && is_object($schemaJson->definitions->{lcfirst($defName)})) {
                         /** @psalm-suppress MixedPropertyFetch, MixedAssignment */
                         $definition = $schemaJson->definitions->{lcfirst($defName)};
                         /** @psalm-suppress MixedPropertyFetch, MixedArgument */
@@ -450,9 +447,9 @@ final class HtmlGenerator
     private function getArrayItemType(Schema $schema): ?string
     {
         $schemaFile = $schema->file->getPathname();
-        $schemaJson = json_decode((string) file_get_contents($schemaFile));
+        $schemaJson = $this->jsonFile->object($schemaFile);
 
-        if (! is_object($schemaJson) || ! isset($schemaJson->items) || ! is_object($schemaJson->items)) {
+        if (! isset($schemaJson->items) || ! is_object($schemaJson->items)) {
             return null; // @codeCoverageIgnore
         }
 

--- a/src/JsonFile.php
+++ b/src/JsonFile.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\ApiDoc\Exception\InvalidJsonFileException;
+use JsonException;
+
+use function array_is_list;
+use function file_get_contents;
+use function is_array;
+use function is_object;
+use function json_decode;
+use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
+
+final class JsonFile
+{
+    public function object(string $file): object
+    {
+        $json = $this->decode($file, false);
+        if (! is_object($json)) {
+            throw new InvalidJsonFileException(sprintf('JSON root must be an object: %s', $file));
+        }
+
+        return $json;
+    }
+
+    /** @return array<string, mixed> */
+    public function assoc(string $file): array
+    {
+        $json = $this->decode($file, true);
+        if (! is_array($json) || array_is_list($json)) {
+            throw new InvalidJsonFileException(sprintf('JSON root must be an object: %s', $file));
+        }
+
+        /** @var array<string, mixed> $json */
+        return $json;
+    }
+
+    private function decode(string $file, bool $assoc): mixed
+    {
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            throw new InvalidJsonFileException(sprintf('Cannot read JSON file: %s', $file));
+        }
+
+        try {
+            return json_decode($contents, $assoc, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidJsonFileException(
+                sprintf('Invalid JSON in %s: %s', $file, $e->getMessage()),
+                0,
+                $e,
+            );
+        }
+    }
+}

--- a/src/OpenApiGenerator.php
+++ b/src/OpenApiGenerator.php
@@ -13,16 +13,12 @@ use SplFileInfo;
 
 use function array_key_exists;
 use function array_map;
-use function assert;
 use function explode;
-use function file_get_contents;
 use function implode;
 use function in_array;
 use function is_array;
 use function is_file;
-use function is_object;
 use function is_string;
-use function json_decode;
 use function json_encode;
 use function pathinfo;
 use function preg_match_all;
@@ -56,11 +52,15 @@ final class OpenApiGenerator
     /** @var array<string, array<string, mixed>> */
     private array $schemas = [];
 
+    private readonly JsonFile $jsonFile;
+
     public function __construct(
         private readonly Config $config,
         private readonly string $requestSchemaDir,
-        private readonly string $responseSchemaDir
+        private readonly string $responseSchemaDir,
+        ?JsonFile $jsonFile = null,
     ) {
+        $this->jsonFile = $jsonFile ?? new JsonFile();
         $this->openApiSpec = [
             'openapi' => '3.1.0',
             'info' => [
@@ -270,16 +270,11 @@ final class OpenApiGenerator
             return null; // @codeCoverageIgnore
         }
 
-        $schemaJson = json_decode((string) file_get_contents($schemaFile));
-        if (! is_object($schemaJson)) {
-            return null; // @codeCoverageIgnore
-        }
-
         $fileInfo = new SplFileInfo($schemaFile);
         /** @var ArrayObject<string, string> $emptyDictionary */
         $emptyDictionary = new ArrayObject();
 
-        return new Schema($fileInfo, $schemaJson, $emptyDictionary);
+        return new Schema($fileInfo, $this->jsonFile->object($schemaFile), $emptyDictionary);
     }
 
     private function addSchemaToComponents(string $schemaName, string $schemaFile): void
@@ -294,17 +289,8 @@ final class OpenApiGenerator
             return; // @codeCoverageIgnore
         }
 
-        $schemaJson = json_decode((string) file_get_contents($schemaPath));
-        if (! is_object($schemaJson)) {
-            return; // @codeCoverageIgnore
-        }
-
-        // Convert to array for OpenAPI
-        /** @var array<string, mixed> $schemaArray */
-        $schemaArray = json_decode((string) json_encode($schemaJson), true);
-
         // Clean up and convert for OpenAPI compatibility
-        $cleanedSchema = $this->cleanSchemaForOpenApi($schemaArray);
+        $cleanedSchema = $this->cleanSchemaForOpenApi($this->jsonFile->assoc($schemaPath));
         $this->schemas[$schemaName] = $this->convertRefs($cleanedSchema);
     }
 
@@ -456,9 +442,8 @@ final class OpenApiGenerator
         // Load the referenced schema to get its title
         $schemaPath = sprintf('%s/%s', $this->responseSchemaDir, $refFile);
         if (is_file($schemaPath)) {
-            $schemaJson = json_decode((string) file_get_contents($schemaPath));
-            assert(is_object($schemaJson) || $schemaJson === null);
-            if (is_object($schemaJson) && isset($schemaJson->title) && is_string($schemaJson->title)) {
+            $schemaJson = $this->jsonFile->object($schemaPath);
+            if (isset($schemaJson->title) && is_string($schemaJson->title)) {
                 return $this->sanitizeSchemaName($schemaJson->title);
             }
         }

--- a/src/Ref.php
+++ b/src/Ref.php
@@ -10,11 +10,9 @@ use SplFileInfo;
 use function assert;
 use function explode;
 use function file_exists;
-use function file_get_contents;
 use function filter_var;
 use function is_object;
 use function is_string;
-use function json_decode;
 use function sprintf;
 use function substr;
 
@@ -60,8 +58,8 @@ final class Ref
     private function getExternalRef(string $ref, SplFileInfo $file): void
     {
         $filePath = $this->getFilePath($ref, $file);
-        $this->json = (object) json_decode((string) file_get_contents($filePath));
-        $schema = (object) json_decode((string) file_get_contents($filePath));
+        $schema = (new JsonFile())->object($filePath);
+        $this->json = $schema;
         $this->type = isset($schema->type) && is_string($schema->type) ? $schema->type : '';
         $this->title = isset($schema->title) && is_string($schema->title) ? $schema->title : '';
     }

--- a/src/XmlLoader.php
+++ b/src/XmlLoader.php
@@ -9,7 +9,6 @@ use BEAR\ApiDoc\Exception\ConfigNotFoundException;
 use DOMDocument;
 use SimpleXMLElement;
 
-use function assert;
 use function dirname;
 use function file_exists;
 use function file_get_contents;
@@ -31,11 +30,21 @@ final class XmlLoader
     public function __invoke(string $xmlPath, string $xsdPath): SimpleXMLElement
     {
         $xmlFullPath = $this->locateConfigFile($xmlPath);
-        $contents = (string) file_get_contents($xmlFullPath);
-        $this->validate($xmlFullPath, $xsdPath);
-        $simpleXml = simplexml_load_string($contents);
-        assert($simpleXml instanceof SimpleXMLElement);
+        $contents = file_get_contents($xmlFullPath);
+        // @codeCoverageIgnoreStart
+        if ($contents === false) {
+            throw new ConfigException(sprintf('Cannot read XML config: %s', $xmlFullPath));
+        }
 
+        // @codeCoverageIgnoreEnd
+        $this->validate($contents, $xmlFullPath, $xsdPath);
+        $simpleXml = simplexml_load_string($contents);
+        // @codeCoverageIgnoreStart
+        if (! $simpleXml instanceof SimpleXMLElement) {
+            throw new ConfigException(sprintf('Invalid XML config: %s', $xmlFullPath));
+        }
+
+        // @codeCoverageIgnoreEnd
         return $simpleXml;
     }
 
@@ -110,29 +119,35 @@ final class XmlLoader
         return null;
     }
 
-    private function validate(string $xmlFullPath, string $xsdPath): void
+    private function validate(string $xmlContents, string $xmlFullPath, string $xsdPath): void
     {
-        libxml_use_internal_errors(true);
-        $dom = new DOMDocument();
-        $dom->load($xmlFullPath);
-        if ($dom->schemaValidate($xsdPath)) {
-            return;
-        }
+        $previous = libxml_use_internal_errors(true);
+        try {
+            $dom = new DOMDocument();
+            if ($dom->loadXML($xmlContents) && $dom->schemaValidate($xsdPath)) {
+                return;
+            }
 
-        $this->error();
+            $this->error($xmlFullPath);
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
     }
 
-    private function error(): void
+    private function error(string $xmlFullPath): void
     {
         $errors = libxml_get_errors();
         foreach ($errors as $error) {
             if ($error->level === LIBXML_ERR_FATAL || $error->level === LIBXML_ERR_ERROR) {
-                libxml_clear_errors();
-
                 $msg = sprintf('%s in %s:%s', substr($error->message, 0, -2), $error->file, $error->line);
 
                 throw new ConfigException($msg);
             }
         }
+
+        // @codeCoverageIgnoreStart
+        throw new ConfigException(sprintf('Invalid XML config: %s', $xmlFullPath));
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/tests/ConfigGeneratorTest.php
+++ b/tests/ConfigGeneratorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use PHPUnit\Framework\TestCase;
+use SimpleXMLElement;
+
+use function assert;
+use function bin2hex;
+use function chdir;
+use function file_get_contents;
+use function file_put_contents;
+use function getcwd;
+use function is_string;
+use function json_encode;
+use function mkdir;
+use function random_bytes;
+use function rmdir;
+use function simplexml_load_string;
+use function sprintf;
+use function sys_get_temp_dir;
+use function unlink;
+
+use const JSON_THROW_ON_ERROR;
+
+class ConfigGeneratorTest extends TestCase
+{
+    public function testEscapesComposerDescriptionInGeneratedXml(): void
+    {
+        $cwd = getcwd();
+        assert(is_string($cwd));
+        $dir = sprintf('%s/bear-apidoc-config-%s', sys_get_temp_dir(), bin2hex(random_bytes(6)));
+        mkdir($dir);
+
+        try {
+            file_put_contents(
+                $dir . '/composer.json',
+                json_encode([
+                    'description' => 'A & <B>',
+                    'autoload' => [
+                        'psr-4' => ['Vendor\\Demo\\' => 'src/'],
+                    ],
+                ], JSON_THROW_ON_ERROR),
+            );
+
+            chdir($dir);
+            (new ConfigGenerator())();
+
+            $xml = file_get_contents($dir . '/apidoc.xml');
+            $this->assertIsString($xml);
+            $this->assertStringContainsString('<description>A &amp; &lt;B&gt;</description>', $xml);
+            $this->assertInstanceOf(SimpleXMLElement::class, simplexml_load_string($xml));
+        } finally {
+            chdir($cwd);
+            @unlink($dir . '/apidoc.xml');
+            @unlink($dir . '/composer.json');
+            @rmdir($dir);
+        }
+    }
+}

--- a/tests/JsonFileTest.php
+++ b/tests/JsonFileTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\ApiDoc\Exception\InvalidJsonFileException;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+class JsonFileTest extends TestCase
+{
+    public function testObjectLoadsJsonObject(): void
+    {
+        $file = $this->writeTempJson('{"title":"Ticket"}');
+
+        try {
+            $json = (new JsonFile())->object($file);
+
+            $this->assertSame('Ticket', $json->title ?? null);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testInvalidJsonReportsFileName(): void
+    {
+        $file = $this->writeTempJson('{');
+
+        $this->expectException(InvalidJsonFileException::class);
+        $this->expectExceptionMessage($file);
+
+        try {
+            (new JsonFile())->object($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testObjectRejectsNonObjectJson(): void
+    {
+        $file = $this->writeTempJson('[]');
+
+        $this->expectException(InvalidJsonFileException::class);
+        $this->expectExceptionMessage('JSON root must be an object');
+
+        try {
+            (new JsonFile())->object($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testAssocRejectsNonObjectJson(): void
+    {
+        $file = $this->writeTempJson('"scalar"');
+
+        $this->expectException(InvalidJsonFileException::class);
+        $this->expectExceptionMessage('JSON root must be an object');
+
+        try {
+            (new JsonFile())->assoc($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testAssocRejectsListRoot(): void
+    {
+        $file = $this->writeTempJson('[]');
+
+        $this->expectException(InvalidJsonFileException::class);
+        $this->expectExceptionMessage('JSON root must be an object');
+
+        try {
+            (new JsonFile())->assoc($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testReadFailureReportsFileName(): void
+    {
+        $file = tempnam(sys_get_temp_dir(), 'bear-apidoc-missing-json-');
+        assert($file !== false);
+        unlink($file);
+
+        $this->expectException(InvalidJsonFileException::class);
+        $this->expectExceptionMessage($file);
+
+        (new JsonFile())->object($file);
+    }
+
+    private function writeTempJson(string $contents): string
+    {
+        $file = tempnam(sys_get_temp_dir(), 'bear-apidoc-json-');
+        assert($file !== false);
+        file_put_contents($file, $contents);
+
+        return $file;
+    }
+}

--- a/tests/XmlLoaderTest.php
+++ b/tests/XmlLoaderTest.php
@@ -9,13 +9,32 @@ use BEAR\ApiDoc\Exception\ConfigNotFoundException;
 use PHPUnit\Framework\TestCase;
 use SimpleXMLElement;
 
+use function assert;
 use function chdir;
 use function dirname;
+use function getcwd;
+use function is_string;
+use function libxml_clear_errors;
+use function libxml_use_internal_errors;
 use function mkdir;
 use function rmdir;
 
 class XmlLoaderTest extends TestCase
 {
+    private string $cwd;
+
+    protected function setUp(): void
+    {
+        $cwd = getcwd();
+        assert(is_string($cwd));
+        $this->cwd = $cwd;
+    }
+
+    protected function tearDown(): void
+    {
+        chdir($this->cwd);
+    }
+
     public function testLoad(): void
     {
         $xml = (new XmlLoader())('', dirname(__DIR__) . '/apidoc.xsd');
@@ -26,6 +45,23 @@ class XmlLoaderTest extends TestCase
     {
         $this->expectException(ConfigException::class);
         (new XmlLoader())(__DIR__ . '/apidoc.error.xml', dirname(__DIR__) . '/apidoc.xsd');
+    }
+
+    public function testInvalidXmlRestoresLibxmlInternalErrors(): void
+    {
+        $previous = libxml_use_internal_errors(false);
+
+        try {
+            try {
+                (new XmlLoader())(__DIR__ . '/apidoc.error.xml', dirname(__DIR__) . '/apidoc.xsd');
+                $this->fail('Expected invalid XML to throw');
+            } catch (ConfigException) {
+                $this->assertFalse(libxml_use_internal_errors());
+            }
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
     }
 
     public function testInvalidXmlPath(): void


### PR DESCRIPTION
## Summary

- Fix the `composer setup` script to use the existing `apidoc init` command.
- Add explicit JSON file loading with contextual exceptions and use it across schema consumers.
- Restore libxml internal error handling after XML validation.
- Detect schema copy and index write failures instead of silently reporting success.
- Escape generated `apidoc.xml` values from `composer.json`.

## Validation

- `composer tests`
- `php /Users/akihito/git/BEAR.ApiDoc/bin/apidoc init` in a temporary project with XML-sensitive composer metadata
