### PR TITLE
Use JSON Schema params for request body properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Preserve JSON Schema param property definitions when expanding OpenAPI request bodies (#84)
 
-### Changed
-- OpenAPI request body property `example` values are now sourced exclusively from JSON Schema `params` files; `@SchemaProp::example` is no longer emitted for request body properties (#84)
-
 ## [1.9.1] - 2026-04-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Emit OpenAPI request inputs for `#[Input]` DTO methods without requiring `#[JsonSchema(params: ...)]` (#81)
 - Fix `composer setup` to call the existing `apidoc init` command instead of a missing setup script (#86)
+- Preserve JSON Schema param property definitions when expanding OpenAPI request bodies (#84)
 - Surface invalid JSON, XML loading, and output write failures during documentation generation (#86)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.2] - Unreleased
+
+### Fixed
+- Preserve JSON Schema param property definitions when expanding OpenAPI request bodies (#84)
+
+### Changed
+- OpenAPI request body property `example` values are now sourced exclusively from JSON Schema `params` files; `@SchemaProp::example` is no longer emitted for request body properties (#84)
+
 ## [1.9.1] - 2026-04-29
 
 ### Fixed
 - Emit OpenAPI request inputs for `#[Input]` DTO methods without requiring `#[JsonSchema(params: ...)]` (#81)
 - Fix `composer setup` to call the existing `apidoc init` command instead of a missing setup script (#86)
-- Preserve JSON Schema param property definitions when expanding OpenAPI request bodies (#84)
 - Surface invalid JSON, XML loading, and output write failures during documentation generation (#86)
 
 ### Changed

--- a/docs/schemas/index.html
+++ b/docs/schemas/index.html
@@ -16,6 +16,7 @@
 <li><a href="card.json" rel="schema">card.json</a></li>
 <li><a href="contact.param.json" rel="schema">contact.param.json</a></li>
 <li><a href="invalid.json" rel="schema">invalid.json</a></li>
+<li><a href="json-schema-input.param.json" rel="schema">json-schema-input.param.json</a></li>
 <li><a href="numbers.json" rel="schema">numbers.json</a></li>
 <li><a href="org.json" rel="schema">org.json</a></li>
 <li><a href="person.json" rel="schema">person.json</a></li>

--- a/docs/schemas/json-schema-input.param.json
+++ b/docs/schemas/json-schema-input.param.json
@@ -1,0 +1,29 @@
+{
+  "$id": "json-schema-input.param.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Schema input parameters",
+  "type": "object",
+  "required": ["ids"],
+  "properties": {
+    "ids": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "minItems": 1,
+      "description": "Identifiers from the request schema",
+      "example": [1, 2, 3]
+    },
+    "status": {
+      "type": ["string", "null"],
+      "enum": ["open", "closed", null],
+      "description": "Nullable ticket status",
+      "example": null
+    },
+    "docOnly": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/OpenApiInputBuilder.php
+++ b/src/OpenApiInputBuilder.php
@@ -8,6 +8,7 @@ use ReflectionMethod;
 use ReflectionNamedType;
 use ReflectionParameter;
 
+use function array_key_exists;
 use function in_array;
 
 /**
@@ -121,13 +122,18 @@ final class OpenApiInputBuilder
         $properties = [];
         /** @var list<string> $required */
         $required = [];
+        $schemaProperties = $schema?->propertySchemas() ?? [];
         foreach ($methodParams as $param) {
             $paramName = $param->getName();
             if (in_array($paramName, $pathParams, true)) {
                 continue;
             }
 
-            $properties[$paramName] = $this->createParameterSchema($param, $schema?->props[$paramName] ?? null);
+            $properties[$paramName] = $this->createRequestBodyPropertySchema(
+                $param,
+                $schemaProperties[$paramName] ?? null,
+                $schema?->props[$paramName] ?? null,
+            );
             if (! $param->isOptional()) {
                 $required[] = $paramName;
             }
@@ -156,6 +162,27 @@ final class OpenApiInputBuilder
         }
 
         return $requestBody;
+    }
+
+    /**
+     * @param array<string, mixed>|null $jsonSchemaProperty
+     *
+     * @return OpenApiParameterSchema
+     */
+    private function createRequestBodyPropertySchema(ReflectionParameter $param, ?array $jsonSchemaProperty, ?SchemaProp $paramSchema): array
+    {
+        if ($jsonSchemaProperty === null) {
+            return $this->createParameterSchema($param, $paramSchema);
+        }
+
+        $schema = $jsonSchemaProperty;
+        $description = $this->getParameterDescription($param, $paramSchema);
+        if ($description !== '' && ! array_key_exists('description', $schema)) {
+            $schema['description'] = $description;
+        }
+
+        /** @var OpenApiParameterSchema $schema */
+        return $schema;
     }
 
     /**
@@ -194,10 +221,6 @@ final class OpenApiInputBuilder
         $description = $this->getParameterDescription($param, $paramSchema);
         if ($description !== '') {
             $schema['description'] = $description;
-        }
-
-        if ($paramSchema instanceof SchemaProp && $paramSchema->example !== '') {
-            $schema['example'] = $paramSchema->example;
         }
 
         return $schema;

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -10,6 +10,7 @@ use SplFileInfo;
 
 use function array_map;
 use function assert;
+use function get_object_vars;
 use function implode;
 use function in_array;
 use function is_array;
@@ -70,6 +71,60 @@ final class Schema
         $title = $this->title !== '' && $this->title !== '0' ? sprintf('%s: %s', ucfirst($this->type), $this->title) : ucfirst($this->type);
 
         return sprintf('[%s](../schemas/%s)', $title, $this->file->getFilename());
+    }
+
+    /** @return array<string, array<string, mixed>> */
+    public function propertySchemas(): array
+    {
+        if (! isset($this->schema->properties) || (! is_array($this->schema->properties) && ! is_object($this->schema->properties))) {
+            return [];
+        }
+
+        /** @var array<string, array<string, mixed>> $properties */
+        $properties = [];
+        foreach ((array) $this->schema->properties as $name => $property) {
+            assert(is_string($name));
+            assert(is_object($property));
+            $properties[$name] = $this->objectToArray($property);
+        }
+
+        return $properties;
+    }
+
+    /**
+     * @return array<string, mixed>
+     *
+     * @psalm-suppress MixedAssignment
+     */
+    private function objectToArray(object $object): array
+    {
+        /** @var array<string, mixed> $array */
+        $array = [];
+        foreach (get_object_vars($object) as $key => $value) {
+            $array[$key] = $this->schemaValueToArray($value);
+        }
+
+        return $array;
+    }
+
+    /** @psalm-suppress MixedAssignment */
+    private function schemaValueToArray(mixed $value): mixed
+    {
+        if (is_object($value)) {
+            return $this->objectToArray($value);
+        }
+
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        /** @var array<array-key, mixed> $array */
+        $array = [];
+        foreach ($value as $key => $item) {
+            $array[$key] = $this->schemaValueToArray($item);
+        }
+
+        return $array;
     }
 
     public function toStringTypeArray(): string

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -83,8 +83,10 @@ final class Schema
         /** @var array<string, array<string, mixed>> $properties */
         $properties = [];
         foreach ((array) $this->schema->properties as $name => $property) {
-            assert(is_string($name));
-            assert(is_object($property));
+            if (! is_string($name) || ! is_object($property)) {
+                continue;
+            }
+
             $properties[$name] = $this->objectToArray($property);
         }
 

--- a/src/Types.php
+++ b/src/Types.php
@@ -18,7 +18,7 @@ namespace BEAR\ApiDoc;
  * @psalm-type OperationBase = array{operationId?: string, summary?: string, description?: string}
  * @psalm-type SchemaRef = array{'$ref': string}
  * @psalm-type OpenApiSchema = array<string, mixed>
- * @psalm-type OpenApiParameterSchema = array{type: string, description?: string, example?: mixed}
+ * @psalm-type OpenApiParameterSchema = array<string, mixed>
  * @psalm-type OpenApiParameter = array{name: string, in: ParameterLocation, required: bool, schema: array{type: string}, description?: string, example?: mixed}
  * @psalm-type OpenApiRequestBody = array{content: array{'application/json': array{schema: array{type: 'object', properties: array<string, OpenApiParameterSchema>, required?: list<string>}}}, required?: bool}
  * @psalm-type OpenApiResponse = array{description: string, content?: array<string, array{schema: SchemaRef}>}

--- a/tests/Fake/Ro/JsonSchemaInput.php
+++ b/tests/Fake/Ro/JsonSchemaInput.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc\Fake\Ro;
+
+final readonly class JsonSchemaInput
+{
+    public function __construct(
+        public mixed $ids,
+        public mixed $status = null,
+        /** DTO docblock fallback description */
+        public mixed $docOnly = null,
+    ) {
+    }
+}

--- a/tests/Fake/Ro/JsonSchemaInputFixture.php
+++ b/tests/Fake/Ro/JsonSchemaInputFixture.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc\Fake\Ro;
+
+use BEAR\Resource\Annotation\JsonSchema;
+use BEAR\Resource\ResourceObject;
+use Ray\InputQuery\Attribute\Input;
+
+final class JsonSchemaInputFixture extends ResourceObject
+{
+    #[JsonSchema(params: 'json-schema-input.param.json')]
+    public function onPost(#[Input] JsonSchemaInput $input, string $fallback): static
+    {
+        return $this;
+    }
+}
+
+final readonly class JsonSchemaInput
+{
+    public function __construct(
+        public mixed $ids,
+        public mixed $status = null,
+        /** DTO docblock fallback description */
+        public mixed $docOnly = null,
+    ) {
+    }
+}

--- a/tests/Fake/Ro/JsonSchemaInputFixture.php
+++ b/tests/Fake/Ro/JsonSchemaInputFixture.php
@@ -16,14 +16,3 @@ final class JsonSchemaInputFixture extends ResourceObject
         return $this;
     }
 }
-
-final readonly class JsonSchemaInput
-{
-    public function __construct(
-        public mixed $ids,
-        public mixed $status = null,
-        /** DTO docblock fallback description */
-        public mixed $docOnly = null,
-    ) {
-    }
-}

--- a/tests/Fake/app/src/var/json_schema/json-schema-input.param.json
+++ b/tests/Fake/app/src/var/json_schema/json-schema-input.param.json
@@ -1,0 +1,29 @@
+{
+  "$id": "json-schema-input.param.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "JSON Schema input parameters",
+  "type": "object",
+  "required": ["ids"],
+  "properties": {
+    "ids": {
+      "type": "array",
+      "items": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "minItems": 1,
+      "description": "Identifiers from the request schema",
+      "example": [1, 2, 3]
+    },
+    "status": {
+      "type": ["string", "null"],
+      "enum": ["open", "closed", null],
+      "description": "Nullable ticket status",
+      "example": null
+    },
+    "docOnly": {
+      "type": "string"
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -63,6 +63,18 @@ class JsonSchemaTest extends TestCase
         $this->assertStringContainsString('Constraints', $output);
     }
 
+    public function testArraySchemaHasNoPropertySchemas(): void
+    {
+        $jsonFile = __DIR__ . '/Fake/app/docs/base/schema/tickets.json';
+        $jsonSchema = new Schema(
+            new SplFileInfo($jsonFile),
+            (object) json_decode((string) file_get_contents($jsonFile)),
+            new ArrayObject()
+        );
+
+        $this->assertSame([], $jsonSchema->propertySchemas());
+    }
+
     public function testSchemaWithSemanticDictionary(): void
     {
         /** @var ArrayObject<string, string> $semanticDictionary */

--- a/tests/OpenApiInputBuilderTest.php
+++ b/tests/OpenApiInputBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace BEAR\ApiDoc;
 
 use ArrayObject;
+use BEAR\ApiDoc\Fake\Ro\JsonSchemaInputFixture;
 use BEAR\ApiDoc\Fake\Ro\PathOnlyInputFixture;
 use BEAR\ApiDoc\Fake\Ro\TypedInputFixture;
 use FakeVendor\FakeProject\Resource\App\ArrayData;
@@ -86,7 +87,33 @@ class OpenApiInputBuilderTest extends TestCase
         $this->assertArrayNotHasKey('required', $requestBody);
         $this->assertArrayNotHasKey('required', $schema);
         $this->assertSame('boolean', $properties['enabled']['type'] ?? null);
-        $this->assertSame('true', $properties['enabled']['example'] ?? null);
+        $this->assertTrue($properties['enabled']['example'] ?? null);
+    }
+
+    public function testRequestBodyUsesJsonSchemaPropertyDefinitionsForExpandedInput(): void
+    {
+        $operation = $this->build(JsonSchemaInputFixture::class, 'onPost', 'post', $this->schema('json-schema-input.param.json'));
+        $properties = $this->requestBodyProperties($operation);
+
+        $this->assertSame(
+            [
+                'type' => 'array',
+                'items' => [
+                    'type' => 'integer',
+                    'minimum' => 1,
+                ],
+                'minItems' => 1,
+                'description' => 'Identifiers from the request schema',
+                'example' => [1, 2, 3],
+            ],
+            $properties['ids'] ?? null,
+        );
+        $this->assertSame(['string', 'null'], $properties['status']['type'] ?? null);
+        $this->assertSame(['open', 'closed', null], $properties['status']['enum'] ?? null);
+        $this->assertArrayHasKey('example', $properties['status']);
+        $this->assertNull($properties['status']['example']);
+        $this->assertSame('DTO docblock fallback description', $properties['docOnly']['description'] ?? null);
+        $this->assertSame('string', $properties['fallback']['type'] ?? null);
     }
 
     public function testUrlPathParameterIsAddedWhenMethodHasNoMatchingArgument(): void


### PR DESCRIPTION
## Summary
- Preserve full JSON Schema property definitions for expanded OpenAPI request bodies
- Keep DTO docblock/schema prop fallbacks when a JSON Schema property omits description or example
- Add fixture coverage for mixed DTO constructor params backed by `#[JsonSchema(params: ...)]`

Closes #84.

## Verification
- `zsh -ic 'sphp85; composer tests'`