### PR TITLE
Add documentation audit and term index reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Add `audit` output format and `apidoc audit` command for documentation coverage reports.
+- Add `terms` output format and `apidoc terms` command for lexical Term Usage Index reports.
+
 ## [1.10.0] - 2026-05-17
 
 ### Added
@@ -140,6 +146,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update dependencies
 
+[Unreleased]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.10.0...HEAD
 [1.10.0]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.2...1.10.0
 [1.9.2]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.1...1.9.2
 [1.9.1]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.0...1.9.1

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ This is a semantic application document, not just an API reference. It describes
 
 - [ApiDoc](https://bearsunday.github.io/BEAR.ApiDoc/)
 - [OpenAPI](https://bearsunday.github.io/BEAR.ApiDoc/openapi/)
+- [Documentation Audit](https://bearsunday.github.io/BEAR.ApiDoc/audit.md)
+- [Term Usage Index](https://bearsunday.github.io/BEAR.ApiDoc/terms.md)
 
 ## Installation
 
@@ -45,6 +47,13 @@ Generate documentation:
 
 ```bash
 ./vendor/bin/apidoc
+```
+
+Generate documentation quality reports:
+
+```bash
+./vendor/bin/apidoc audit
+./vendor/bin/apidoc terms
 ```
 
 ## Usage
@@ -74,7 +83,7 @@ jobs:
 | Input | Default | Description |
 |-------|---------|-------------|
 | `php-version` | `'8.2'` | PHP version |
-| `format` | `'html,openapi,llms'` | Comma-separated: html (apidoc), md, openapi, alps, llms |
+| `format` | `'html,openapi,llms'` | Comma-separated: html (apidoc), md, openapi, alps, llms, audit, terms |
 | `alps-profile` | `''` | ALPS profile path (required for alps format) |
 | `docs-path` | `'docs/api'` | Output directory |
 | `publish-to` | `'github-pages'` | `github-pages` or `artifact-only` |
@@ -84,6 +93,8 @@ jobs:
 ```text
 docs/
 ├── index.html          # API documentation
+├── audit.md            # Documentation coverage report
+├── terms.md            # Term usage index
 ├── llms.txt            # AI-readable overview
 ├── openapi.json        # OpenAPI spec
 └── schemas/
@@ -100,6 +111,8 @@ composer docs        # Generate docs with external CSS
 composer docs-dev    # Generate docs with inline CSS for development
 composer docs-md     # Generate Markdown docs
 composer docs-openapi # Generate OpenAPI spec
+composer docs-audit  # Generate documentation audit report
+composer docs-terms  # Generate term usage index
 ```
 
 Application as Documentation.

--- a/apidoc.xsd
+++ b/apidoc.xsd
@@ -43,11 +43,11 @@
     </xs:element>
     <xs:element name="format">
         <xs:annotation>
-            <xs:documentation>Output document format (comma-separated for multiple: html,llms)</xs:documentation>
+            <xs:documentation>Output document format (comma-separated for multiple: html,llms,audit,terms)</xs:documentation>
         </xs:annotation>
         <xs:simpleType>
             <xs:restriction base="xs:string">
-                <xs:pattern value="(html|md|openapi|llms)(,(html|md|openapi|llms))*"/>
+                <xs:pattern value="(html|md|openapi|llms|audit|terms)(,(html|md|openapi|llms|audit|terms))*"/>
             </xs:restriction>
         </xs:simpleType>
     </xs:element>

--- a/bin/apidoc
+++ b/bin/apidoc
@@ -2,7 +2,10 @@
 <?php
 
 use BEAR\ApiDoc\ApiDoc;
+use BEAR\ApiDoc\ApiDocAudit;
+use BEAR\ApiDoc\Config;
 use BEAR\ApiDoc\ConfigGenerator;
+use BEAR\ApiDoc\TermUsageIndex;
 
 /**
  * @param array<int,string> $argv
@@ -16,11 +19,36 @@ use BEAR\ApiDoc\ConfigGenerator;
         }
     }
 
-    // Handle 'init' subcommand
     if (isset($argv[1]) && $argv[1] === 'init') {
         try {
             $generator = new ConfigGenerator();
             echo $generator() . PHP_EOL;
+        } catch (RuntimeException $e) {
+            printf("%s: %s\n", (new ReflectionClass($e))->getShortName(), $e->getMessage());
+            exit(1);
+        }
+        return;
+    }
+
+    if (isset($argv[1]) && in_array($argv[1], ['audit', 'terms'], true)) {
+        $apidocXml = './apidoc.xml';
+        foreach ($argv as $index => $arg) {
+            if ($arg === '-c' && isset($argv[$index + 1])) {
+                $apidocXml = $argv[$index + 1];
+                continue;
+            }
+
+            if (str_starts_with($arg, '-c') && $arg !== '-c') {
+                $apidocXml = substr($arg, 2);
+            }
+        }
+
+        try {
+            $config = new Config($apidocXml);
+            echo match ($argv[1]) {
+                'audit' => (new ApiDocAudit($config))->generateMarkdown(),
+                'terms' => (new TermUsageIndex($config))->generateMarkdown(),
+            };
         } catch (RuntimeException $e) {
             printf("%s: %s\n", (new ReflectionClass($e))->getShortName(), $e->getMessage());
             exit(1);

--- a/composer.json
+++ b/composer.json
@@ -83,10 +83,14 @@
         "docs-dev": "php bin/apidoc -ctests/apidoc.html.xml --inline-css",
         "docs-md": "php bin/apidoc -ctests/apidoc.md.xml",
         "docs-openapi": "php bin/apidoc -ctests/apidoc.openapi.xml",
+        "docs-audit": "php bin/apidoc -ctests/apidoc.demo-audit.xml",
+        "docs-terms": "php bin/apidoc -ctests/apidoc.demo-terms.xml",
         "docs-all": [
             "@docs",
             "@docs-md",
-            "@docs-openapi"
+            "@docs-openapi",
+            "@docs-audit",
+            "@docs-terms"
         ],
         "openapi-install": "npm install -g @redocly/cli",
         "openapi-lint": "npx @redocly/cli lint tests/docs/openapi/openapi.json",

--- a/docs/audit.md
+++ b/docs/audit.md
@@ -1,0 +1,124 @@
+# API Documentation Audit
+
+## Summary
+- Resources: 19
+- Operations: 28
+- Operations with response schema: 11
+- Operations with request schema: 12
+- Operations with ALPS attributes: 6
+
+## Findings
+### GET /address
+- Missing ALPS attribute.
+
+### GET /alps-fallback
+- Missing response schema.
+- Missing ALPS attribute.
+
+### GET /array-data
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### GET /calendar/{year}/{month}
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### GET /card
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### POST /contact
+- Missing response schema.
+- Missing request schema for non-path body input.
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### POST /contact-with-descriptions
+- Missing response schema.
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### POST /docblock-variants
+- Missing response schema.
+- Missing request schema for non-path body input.
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### GET /index
+- Missing response schema.
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### POST /input-edge-cases
+- Missing response schema.
+- Missing request schema for non-path body input.
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### PUT /input-edge-cases
+- Missing response schema.
+- Missing request schema for non-path body input.
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### GET /missing-schema
+- Missing ALPS attribute.
+
+### GET /numbers
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### GET /org
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### PATCH /person
+- Missing response schema.
+- Missing ALPS attribute.
+
+### POST /person
+- Missing response schema.
+
+### PUT /ticket/assign
+- Missing response schema.
+- Missing request schema for non-path body input.
+- Missing ALPS attribute.
+
+### DELETE /ticket/{id}
+- Missing response schema.
+- Missing ALPS attribute.
+
+### GET /ticket/{id}
+- Missing ALPS attribute.
+
+### POST /ticket/{id}
+- Missing response schema.
+- Missing ALPS attribute.
+
+### PUT /ticket/{id}
+- Missing response schema.
+- Missing ALPS attribute.
+
+### GET /tickets
+- Missing resource class summary.
+- Missing operation summary.
+- Missing ALPS attribute.
+
+### GET /union-type
+- Missing response schema.
+- Missing resource class summary.
+- Missing ALPS attribute.
+
+### DELETE /users/{id}
+- Missing response schema.
+
+### POST /users/{id}
+- Missing response schema.
+
+### PUT /users/{id}
+- Missing response schema.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1781,7 +1781,7 @@ tr:hover {
 
 
 <h2>Links</h2>
-<ul class="doc-links"><li><strong>home</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc">https://github.com/bearsunday/BEAR.ApiDoc</a></li><li><strong>issues</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc/issues">https://github.com/bearsunday/BEAR.ApiDoc/issues</a></li><li><strong>profile</strong> : <a href="alps/">alps/</a></li><li><strong>openapi</strong> : <a href="openapi/openapi.json">openapi/openapi.json</a></li><li><strong>openapi-html</strong> : <a href="openapi/">openapi/</a></li></ul>
+<ul class="doc-links"><li><strong>home</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc">https://github.com/bearsunday/BEAR.ApiDoc</a></li><li><strong>issues</strong> : <a href="https://github.com/bearsunday/BEAR.ApiDoc/issues">https://github.com/bearsunday/BEAR.ApiDoc/issues</a></li><li><strong>profile</strong> : <a href="alps/">alps/</a></li><li><strong>openapi</strong> : <a href="openapi/openapi.json">openapi/openapi.json</a></li><li><strong>openapi-html</strong> : <a href="openapi/">openapi/</a></li><li><strong>audit</strong> : <a href="audit.md">audit.md</a></li><li><strong>terms</strong> : <a href="terms.md">terms.md</a></li></ul>
 
 </div>
 </body>

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -1,0 +1,472 @@
+# Term Usage Index
+
+This index reports lexical identifier matches only; it does not prove semantic equivalence.
+
+## Summary
+
+- Terms used in API: 73
+- Terms with same-name ALPS descriptor: 4
+- Lexical ALPS coverage: 5.5%
+- Reserved representation fields: 2
+- ☑︎ = ALPS descriptor binding
+
+## Terms
+
+### Term: `additionalName`
+
+- usages:
+  - schema property: card.json#/properties/additionalName
+
+### Term: `age` ☑︎
+
+- title: Age in years which must be equal to or greater than zero.
+- usages:
+  - parameter: GET /alps-fallback {age}
+  - parameter: POST /contact {age}
+  - parameter: POST /contact-with-descriptions {age}
+  - parameter: POST /person {age}
+  - parameter: PATCH /person {age}
+  - parameter: POST /users/{id} {age}
+  - parameter: PUT /users/{id} {age}
+  - schema property: contact.param.json#/properties/age
+  - schema property: person.json#/properties/age
+  - schema property: person.param.json#/properties/age
+  - schema property: user.json#/properties/age
+  - schema property: user.param.json#/properties/age
+
+### Term: `assignee`
+
+- usages:
+  - parameter: POST /ticket/{id} {assignee}
+  - parameter: PUT /ticket/{id} {assignee}
+  - parameter: PUT /ticket/assign {assignee}
+  - schema property: ticket.json#/properties/assignee
+  - schema property: ticket.param.json#/properties/assignee
+
+### Term: `bday`
+
+- usages:
+  - schema property: card.json#/properties/bday
+
+### Term: `bothSummaryAndDescription`
+
+- usages:
+  - parameter: POST /docblock-variants {bothSummaryAndDescription}
+
+### Term: `builtinType`
+
+- usages:
+  - parameter: POST /input-edge-cases {builtinType}
+
+### Term: `category`
+
+- usages:
+  - schema property: calendar.json#/properties/category
+
+### Term: `count`
+
+- usages:
+  - parameter: GET /numbers {count}
+
+### Term: `country-name`
+
+- usages:
+  - schema property: address.json#/properties/country-name
+
+### Term: `created`
+
+- usages:
+  - schema property: ticket.json#/properties/created
+  - schema property: user.json#/properties/created
+
+### Term: `date`
+
+- usages:
+  - parameter: GET /calendar/{year}/{month} {date}
+
+### Term: `description`
+
+- usages:
+  - parameter: POST /ticket/{id} {description}
+  - parameter: PUT /ticket/{id} {description}
+  - schema property: calendar.json#/properties/description
+  - schema property: ticket.json#/properties/description
+  - schema property: ticket.param.json#/properties/description
+
+### Term: `docOnly`
+
+- usages:
+  - schema property: json-schema-input.param.json#/properties/docOnly
+
+### Term: `dtend`
+
+- usages:
+  - schema property: calendar.json#/properties/dtend
+
+### Term: `dtstart`
+
+- usages:
+  - schema property: calendar.json#/properties/dtstart
+
+### Term: `duration`
+
+- usages:
+  - schema property: calendar.json#/properties/duration
+
+### Term: `email`
+
+- usages:
+  - parameter: POST /contact {email}
+  - parameter: POST /contact-with-descriptions {email}
+  - parameter: POST /users/{id} {email}
+  - parameter: PUT /users/{id} {email}
+  - schema property: card.json#/properties/email
+  - schema property: contact.param.json#/properties/email
+  - schema property: user.json#/properties/email
+  - schema property: user.param.json#/properties/email
+
+### Term: `enabled`
+
+- usages:
+  - parameter: PUT /users/{id} {enabled}
+  - schema property: user.json#/properties/enabled
+  - schema property: user.param.json#/properties/enabled
+
+### Term: `extended-address`
+
+- usages:
+  - schema property: address.json#/properties/extended-address
+
+### Term: `familyName` ☑︎
+
+- def: https://schema.org/familyName
+- usages:
+  - parameter: GET /alps-fallback {familyName}
+  - parameter: POST /person {familyName}
+  - parameter: PATCH /person {familyName}
+  - schema property: card.json#/properties/familyName
+  - schema property: person.json#/properties/familyName
+  - schema property: person.param.json#/properties/familyName
+
+### Term: `firstName` ☑︎
+
+- title: First Name by ALPS
+- usages:
+  - parameter: GET /alps-fallback {firstName}
+  - parameter: POST /person {firstName}
+  - parameter: PATCH /person {firstName}
+  - schema property: person.json#/properties/firstName
+  - schema property: person.param.json#/properties/firstName
+  - schema property: user.json#/properties/firstName
+
+### Term: `fn`
+
+- usages:
+  - schema property: card.json#/properties/fn
+
+### Term: `foo`
+
+- usages:
+  - parameter: GET /alps-fallback {foo}
+
+### Term: `fruits`
+
+- usages:
+  - schema property: array.json#/properties/fruits
+
+### Term: `givenName`
+
+- usages:
+  - schema property: card.json#/properties/givenName
+
+### Term: `honorificPrefix`
+
+- usages:
+  - schema property: card.json#/properties/honorificPrefix
+
+### Term: `honorificSuffix`
+
+- usages:
+  - schema property: card.json#/properties/honorificSuffix
+
+### Term: `href`
+
+- usages:
+  - schema property: user.json#/properties/_links/properties/self/properties/href
+
+### Term: `id` ☑︎
+
+- title: Person identifier
+- usages:
+  - parameter: GET /address {id}
+  - parameter: GET /card {id}
+  - parameter: GET /org {id}
+  - parameter: GET /person {id}
+  - parameter: PATCH /person {id}
+  - parameter: GET /ticket/{id} {id}
+  - parameter: PUT /ticket/{id} {id}
+  - parameter: DELETE /ticket/{id} {id}
+  - parameter: PUT /ticket/assign {id}
+  - parameter: GET /union-type {id}
+  - parameter: GET /users/{id} {id}
+  - parameter: PUT /users/{id} {id}
+  - parameter: DELETE /users/{id} {id}
+  - schema property: org.json#/properties/id
+  - schema property: person.param.json#/properties/id
+  - schema property: ticket.json#/properties/id
+  - schema property: ticket.param.json#/properties/id
+  - schema property: user.json#/properties/id
+  - schema property: user.param.json#/properties/id
+
+### Term: `ids`
+
+- usages:
+  - schema property: json-schema-input.param.json#/properties/ids
+
+### Term: `items`
+
+- usages:
+  - parameter: GET /array-data {items}
+
+### Term: `juice`
+
+- usages:
+  - schema property: array.json#/properties/juice
+
+### Term: `juiceLike`
+
+- usages:
+  - schema property: array.json#/definitions/juice/properties/juiceLike
+
+### Term: `juiceName`
+
+- usages:
+  - schema property: array.json#/definitions/juice/properties/juiceName
+
+### Term: `lastName`
+
+- usages:
+  - schema property: user.json#/properties/lastName
+
+### Term: `locality`
+
+- usages:
+  - schema property: address.json#/properties/locality
+
+### Term: `location`
+
+- usages:
+  - schema property: calendar.json#/properties/location
+
+### Term: `logo`
+
+- usages:
+  - schema property: card.json#/properties/logo
+
+### Term: `modified`
+
+- usages:
+  - schema property: user.json#/properties/modified
+
+### Term: `name`
+
+- usages:
+  - parameter: POST /contact {name}
+  - parameter: POST /contact-with-descriptions {name}
+  - parameter: POST /users/{id} {name}
+  - parameter: PUT /users/{id} {name}
+  - schema property: contact.param.json#/properties/name
+  - schema property: org.json#/properties/name
+  - schema property: user.param.json#/properties/name
+
+### Term: `nickname`
+
+- usages:
+  - schema property: card.json#/properties/nickname
+
+### Term: `noCtor`
+
+- usages:
+  - parameter: PUT /input-edge-cases {noCtor}
+
+### Term: `nonPromoted`
+
+- usages:
+  - parameter: POST /docblock-variants {nonPromoted}
+
+### Term: `options`
+
+- usages:
+  - parameter: GET /users/{id} {options}
+  - schema property: user.param.json#/properties/options
+
+### Term: `org`
+
+- usages:
+  - schema property: card.json#/properties/org
+
+### Term: `organizationName`
+
+- usages:
+  - schema property: card.json#/properties/org/properties/organizationName
+
+### Term: `organizationUnit`
+
+- usages:
+  - schema property: card.json#/properties/org/properties/organizationUnit
+
+### Term: `photo`
+
+- usages:
+  - schema property: card.json#/properties/photo
+
+### Term: `post-office-box`
+
+- usages:
+  - schema property: address.json#/properties/post-office-box
+
+### Term: `postal-code`
+
+- usages:
+  - schema property: address.json#/properties/postal-code
+
+### Term: `priority`
+
+- usages:
+  - schema property: ticket.json#/properties/priority
+
+### Term: `rdate`
+
+- usages:
+  - schema property: calendar.json#/properties/rdate
+
+### Term: `region`
+
+- usages:
+  - schema property: address.json#/properties/region
+
+### Term: `role`
+
+- usages:
+  - schema property: card.json#/properties/role
+
+### Term: `rrule`
+
+- usages:
+  - schema property: calendar.json#/properties/rrule
+
+### Term: `self`
+
+- usages:
+  - schema property: user.json#/properties/_links/properties/self
+
+### Term: `sound`
+
+- usages:
+  - schema property: card.json#/properties/sound
+
+### Term: `status`
+
+- usages:
+  - parameter: PUT /ticket/{id} {status}
+  - schema property: json-schema-input.param.json#/properties/status
+  - schema property: ticket.json#/properties/status
+  - schema property: ticket.param.json#/properties/status
+
+### Term: `street-address`
+
+- usages:
+  - schema property: address.json#/properties/street-address
+
+### Term: `subject`
+
+- usages:
+  - parameter: POST /contact {subject}
+  - parameter: POST /contact-with-descriptions {subject}
+  - schema property: contact.param.json#/properties/subject
+
+### Term: `summary`
+
+- usages:
+  - schema property: calendar.json#/properties/summary
+
+### Term: `tagOnly`
+
+- usages:
+  - parameter: POST /docblock-variants {tagOnly}
+
+### Term: `tel`
+
+- usages:
+  - schema property: card.json#/properties/tel
+
+### Term: `tickets`
+
+- usages:
+  - schema property: user.json#/properties/_embedded/properties/tickets
+
+### Term: `title`
+
+- usages:
+  - parameter: POST /ticket/{id} {title}
+  - parameter: PUT /ticket/{id} {title}
+  - schema property: card.json#/properties/title
+  - schema property: ticket.json#/properties/title
+  - schema property: ticket.param.json#/properties/title
+
+### Term: `type`
+
+- usages:
+  - schema property: card.json#/properties/email/properties/type
+  - schema property: card.json#/properties/tel/properties/type
+
+### Term: `tz`
+
+- usages:
+  - schema property: card.json#/properties/tz
+
+### Term: `updated`
+
+- usages:
+  - schema property: ticket.json#/properties/updated
+
+### Term: `url`
+
+- usages:
+  - schema property: calendar.json#/properties/url
+  - schema property: card.json#/properties/url
+
+### Term: `value`
+
+- usages:
+  - schema property: card.json#/properties/email/properties/value
+  - schema property: card.json#/properties/tel/properties/value
+
+### Term: `vegetables`
+
+- usages:
+  - schema property: array.json#/properties/vegetables
+
+### Term: `veggieLike`
+
+- usages:
+  - schema property: array.json#/definitions/veggie/properties/veggieLike
+
+### Term: `veggieName`
+
+- usages:
+  - schema property: array.json#/definitions/veggie/properties/veggieName
+
+## Reserved Representation Fields
+
+Leading-underscore fields are listed separately because they usually belong to the representation format rather than the API domain vocabulary.
+
+### Field: `_embedded`
+
+- usages:
+  - schema property: user.json#/properties/_embedded
+
+### Field: `_links`
+
+- usages:
+  - schema property: user.json#/properties/_links

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -56,9 +56,11 @@ final readonly class ApiDoc
         foreach ($config->formats as $format) {
             $this->dumpFormat($config, $docClass, $format, $fakeDataExampleResolver);
             $outputFiles[] = match ($format) {
+                'audit' => 'audit.md',
                 'openapi' => 'openapi.json',
                 'md' => 'index.md',
                 'llms' => 'llms.txt',
+                'terms' => 'terms.md',
                 default => 'index.html',
             };
         }
@@ -84,6 +86,18 @@ final readonly class ApiDoc
 
         if ($format === 'llms') {
             $this->dumpLlms($config);
+
+            return;
+        }
+
+        if ($format === 'audit') {
+            $this->dumpAudit($config);
+
+            return;
+        }
+
+        if ($format === 'terms') {
+            $this->dumpTerms($config);
 
             return;
         }
@@ -282,5 +296,17 @@ final readonly class ApiDoc
         $content = $generator->generate();
         $outputFile = sprintf('%s/llms.txt', $config->docDir);
         $this->filePutContents($outputFile, $content);
+    }
+
+    private function dumpAudit(Config $config): void
+    {
+        $outputFile = sprintf('%s/audit.md', $config->docDir);
+        $this->filePutContents($outputFile, (new ApiDocAudit($config))->generateMarkdown());
+    }
+
+    private function dumpTerms(Config $config): void
+    {
+        $outputFile = sprintf('%s/terms.md', $config->docDir);
+        $this->filePutContents($outputFile, (new TermUsageIndex($config))->generateMarkdown());
     }
 }

--- a/src/ApiDocAudit.php
+++ b/src/ApiDocAudit.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\ApiDoc\Annotation\Alps;
+use BEAR\Resource\Annotation\JsonSchema;
+use phpDocumentor\Reflection\DocBlockFactory;
+use ReflectionClass;
+use ReflectionMethod;
+use Throwable;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function count;
+use function implode;
+use function in_array;
+use function is_string;
+use function preg_match_all;
+use function sprintf;
+use function strcmp;
+use function strtoupper;
+use function substr;
+use function trim;
+use function usort;
+
+/**
+ * @psalm-type AuditOperation = array{
+ *     path: string,
+ *     method: string,
+ *     hasResponseSchema: bool,
+ *     hasRequestSchema: bool,
+ *     hasAlps: bool,
+ *     hasClassSummary: bool,
+ *     hasMethodSummary: bool,
+ *     hasRequestBodyInput: bool
+ * }
+ */
+final class ApiDocAudit
+{
+    private const METHOD_ORDER = [
+        'DELETE' => 0,
+        'GET' => 1,
+        'PATCH' => 2,
+        'POST' => 3,
+        'PUT' => 4,
+    ];
+
+    public function __construct(private readonly Config $config)
+    {
+    }
+
+    public function generateMarkdown(): string
+    {
+        $operations = $this->collectOperations();
+        $findings = [];
+
+        foreach ($operations as $operation) {
+            $operationFindings = $this->findingsFor($operation);
+            if ($operationFindings === []) {
+                continue;
+            }
+
+            $findings[] = sprintf('### %s %s', $operation['method'], $operation['path']);
+
+            foreach ($operationFindings as $finding) {
+                $findings[] = sprintf('- %s', $finding);
+            }
+
+            $findings[] = '';
+        }
+
+        $summary = [
+            '# API Documentation Audit',
+            '',
+            '## Summary',
+            sprintf('- Resources: %d', count($this->config->resourceFiles)),
+            sprintf('- Operations: %d', count($operations)),
+            sprintf('- Operations with response schema: %d', count(array_filter($operations, static fn (array $operation): bool => $operation['hasResponseSchema']))),
+            sprintf('- Operations with request schema: %d', count(array_filter($operations, static fn (array $operation): bool => $operation['hasRequestSchema']))),
+        ];
+
+        if ($this->alpsEnabled()) {
+            $summary[] = sprintf('- Operations with ALPS attributes: %d', count(array_filter($operations, static fn (array $operation): bool => $operation['hasAlps'])));
+        }
+
+        $summary[] = '';
+        $summary[] = '## Findings';
+
+        if ($findings === []) {
+            $summary[] = 'No documentation gaps found.';
+        }
+
+        return implode("\n", [...$summary, ...$findings]);
+    }
+
+    /** @return list<AuditOperation> */
+    private function collectOperations(): array
+    {
+        /** @var list<AuditOperation> $operations */
+        $operations = [];
+
+        foreach ($this->config->resourceFiles as $meta) {
+            $path = $this->config->routes[$meta->uriPath] ?? $meta->uriPath;
+            /** @var ReflectionClass<object> $class */
+            $class = new ReflectionClass($meta->class);
+            $hasClassSummary = $this->hasSummary($class->getDocComment());
+            $hasClassAlps = $class->getAttributes(Alps::class) !== [];
+
+            foreach ($class->getMethods() as $method) {
+                $methodName = $method->getName();
+                if (! in_array($methodName, ['onGet', 'onPut', 'onPost', 'onPatch', 'onDelete'], true)) {
+                    continue;
+                }
+
+                $httpMethod = strtoupper(substr($methodName, 2));
+                [$hasResponseSchema, $hasRequestSchema] = $this->jsonSchemaCoverage($method);
+
+                $operations[] = [
+                    'path' => $path,
+                    'method' => $httpMethod,
+                    'hasResponseSchema' => $hasResponseSchema,
+                    'hasRequestSchema' => $hasRequestSchema,
+                    'hasAlps' => $hasClassAlps || $method->getAttributes(Alps::class) !== [],
+                    'hasClassSummary' => $hasClassSummary,
+                    'hasMethodSummary' => $this->hasSummary($method->getDocComment()),
+                    'hasRequestBodyInput' => $this->hasRequestBodyInput($method, $httpMethod, $path),
+                ];
+            }
+        }
+
+        usort($operations, self::compareOperation(...));
+
+        return $operations;
+    }
+
+    /**
+     * @param AuditOperation $left
+     * @param AuditOperation $right
+     */
+    private static function compareOperation(array $left, array $right): int
+    {
+        $pathComparison = strcmp($left['path'], $right['path']);
+        if ($pathComparison !== 0) {
+            return $pathComparison;
+        }
+
+        return (self::METHOD_ORDER[$left['method']] ?? 99) <=> (self::METHOD_ORDER[$right['method']] ?? 99);
+    }
+
+    /** @return array{bool, bool} */
+    private function jsonSchemaCoverage(ReflectionMethod $method): array
+    {
+        $attributes = $method->getAttributes(JsonSchema::class);
+        if ($attributes === []) {
+            return [false, false];
+        }
+
+        $jsonSchema = $attributes[0]->newInstance();
+
+        return [$jsonSchema->schema !== '', $jsonSchema->params !== ''];
+    }
+
+    private function hasSummary(string|false $docComment): bool
+    {
+        if (! is_string($docComment) || trim($docComment) === '') {
+            return false;
+        }
+
+        try {
+            $docBlock = DocBlockFactory::createInstance()->create($docComment);
+        } catch (Throwable) { // @codeCoverageIgnore
+            return false; // @codeCoverageIgnore
+        }
+
+        return trim($docBlock->getSummary()) !== '';
+    }
+
+    private function hasRequestBodyInput(ReflectionMethod $method, string $httpMethod, string $path): bool
+    {
+        if (! in_array($httpMethod, ['POST', 'PUT', 'PATCH'], true)) {
+            return false;
+        }
+
+        preg_match_all('/\{([^}]+)\}/', $path, $matches);
+        $pathParams = $matches[1];
+        $inputParams = array_map(
+            static fn ($param): string => $param->getName(),
+            (new InputParamExpander())($method),
+        );
+
+        return array_values(array_filter(
+            $inputParams,
+            static fn (string $param): bool => ! in_array($param, $pathParams, true),
+        )) !== [];
+    }
+
+    /**
+     * @param AuditOperation $operation
+     *
+     * @return list<string>
+     */
+    private function findingsFor(array $operation): array
+    {
+        $findings = [];
+        if (! $operation['hasResponseSchema']) {
+            $findings[] = 'Missing response schema.';
+        }
+
+        if ($operation['hasRequestBodyInput'] && ! $operation['hasRequestSchema']) {
+            $findings[] = 'Missing request schema for non-path body input.';
+        }
+
+        if (! $operation['hasClassSummary']) {
+            $findings[] = 'Missing resource class summary.';
+        }
+
+        if (! $operation['hasMethodSummary']) {
+            $findings[] = 'Missing operation summary.';
+        }
+
+        if ($this->alpsEnabled() && ! $operation['hasAlps']) {
+            $findings[] = 'Missing ALPS attribute.';
+        }
+
+        return $findings;
+    }
+
+    private function alpsEnabled(): bool
+    {
+        return $this->config->alps !== '' && $this->config->alps !== '0';
+    }
+}

--- a/src/ConfigGenerator.php
+++ b/src/ConfigGenerator.php
@@ -40,7 +40,7 @@ final class ConfigGenerator
     <appName>%s</appName>
     <scheme>app</scheme>
     <docDir>docs</docDir>
-    <!-- format: html | md | openapi | llms -->
+    <!-- format: html | md | openapi | llms | audit | terms -->
     <format>html</format>
     <title>%s API Doc</title>%s
     <links>

--- a/src/TermUsageIndex.php
+++ b/src/TermUsageIndex.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionMethod;
+use SimpleXMLElement;
+use SplFileInfo;
+
+use function array_key_exists;
+use function array_keys;
+use function assert;
+use function basename;
+use function count;
+use function file_exists;
+use function implode;
+use function is_array;
+use function is_dir;
+use function is_file;
+use function is_string;
+use function ksort;
+use function pathinfo;
+use function round;
+use function rtrim;
+use function simplexml_load_file;
+use function sprintf;
+use function str_ends_with;
+use function str_replace;
+use function str_starts_with;
+use function strtoupper;
+use function substr;
+use function trim;
+use function usort;
+
+use const PATHINFO_EXTENSION;
+use const PHP_EOL;
+
+/** @psalm-type AlpsDescriptor = array{title?: string, def?: string, doc?: string} */
+final class TermUsageIndex
+{
+    /** @var array<string, array<string, true>> */
+    private array $apiUsages = [];
+
+    /** @var array<string, array<string, true>> */
+    private array $reservedUsages = [];
+
+    /** @var array<string, AlpsDescriptor> */
+    private array $alpsDescriptors = [];
+
+    public function __construct(
+        private readonly Config $config,
+        private readonly InputParamExpander $inputParamExpander = new InputParamExpander(),
+        private readonly JsonFile $jsonFile = new JsonFile(),
+    ) {
+    }
+
+    public function generateMarkdown(): string
+    {
+        $this->apiUsages = [];
+        $this->reservedUsages = [];
+        $this->alpsDescriptors = [];
+        $this->collectParameterUsages();
+        $this->collectSchemaPropertyUsages($this->config->requestSchemaDir);
+        $this->collectSchemaPropertyUsages($this->config->responseSchemaDir);
+        $this->collectAlpsDescriptors();
+
+        /** @var array<string, array<string, true>> $apiUsages */
+        $apiUsages = $this->apiUsages;
+        /** @var array<string, array<string, true>> $reservedUsages */
+        $reservedUsages = $this->reservedUsages;
+        /** @var array<string, AlpsDescriptor> $alpsDescriptors */
+        $alpsDescriptors = $this->alpsDescriptors;
+        ksort($apiUsages);
+        ksort($reservedUsages);
+        ksort($alpsDescriptors);
+        $matchedAlpsDescriptorCount = $this->matchedAlpsDescriptorCount($apiUsages, $alpsDescriptors);
+
+        $lines = [
+            '# Term Usage Index',
+            '',
+            'This index reports lexical identifier matches only; it does not prove semantic equivalence.',
+            '',
+            '## Summary',
+            '',
+            sprintf('- Terms used in API: %d', count($apiUsages)),
+            sprintf('- Terms with same-name ALPS descriptor: %d', $matchedAlpsDescriptorCount),
+            sprintf('- Lexical ALPS coverage: %s%%', $this->coveragePercent(count($apiUsages), $matchedAlpsDescriptorCount)),
+            sprintf('- Reserved representation fields: %d', count($reservedUsages)),
+            '- ☑︎ = ALPS descriptor binding',
+            '',
+            '## Terms',
+            '',
+        ];
+
+        foreach ($apiUsages as $term => $usages) {
+            $descriptor = $alpsDescriptors[$term] ?? null;
+            $lines[] = sprintf('### Term: `%s`%s', $term, $descriptor !== null ? ' ☑︎' : '');
+            $lines[] = '';
+
+            if ($descriptor !== null) {
+                foreach (['title', 'def', 'doc'] as $field) {
+                    $value = $descriptor[$field] ?? '';
+                    if ($value === '') {
+                        continue;
+                    }
+
+                    $lines[] = sprintf('- %s: %s', $field, $value);
+                }
+            }
+
+            $lines[] = '- usages:';
+            foreach (array_keys($usages) as $usage) {
+                $lines[] = sprintf('  - %s', $usage);
+            }
+
+            $lines[] = '';
+        }
+
+        if ($reservedUsages !== []) {
+            $lines[] = '## Reserved Representation Fields';
+            $lines[] = '';
+            $lines[] = 'Leading-underscore fields are listed separately because they usually belong to the representation format rather than the API domain vocabulary.';
+            $lines[] = '';
+
+            foreach ($reservedUsages as $term => $usages) {
+                $lines[] = sprintf('### Field: `%s`', $term);
+                $lines[] = '';
+                $lines[] = '- usages:';
+                foreach (array_keys($usages) as $usage) {
+                    $lines[] = sprintf('  - %s', $usage);
+                }
+
+                $lines[] = '';
+            }
+        }
+
+        return rtrim(implode(PHP_EOL, $lines)) . PHP_EOL;
+    }
+
+    private function collectParameterUsages(): void
+    {
+        foreach ($this->sortedResourceFiles() as $meta) {
+            $path = $this->config->routes[$meta->uriPath] ?? $meta->uriPath;
+            $class = new ReflectionClass($meta->class);
+            foreach ($class->getMethods() as $method) {
+                if (! $this->isResourceMethod($method)) {
+                    continue;
+                }
+
+                $httpMethod = strtoupper(substr($method->getName(), 2));
+                foreach (($this->inputParamExpander)($method) as $parameter) {
+                    $term = $parameter->getName();
+                    $this->addUsage($term, sprintf('parameter: %s %s {%s}', $httpMethod, $path, $term));
+                }
+            }
+        }
+    }
+
+    private function collectSchemaPropertyUsages(string $schemaDir): void
+    {
+        if ($schemaDir === '' || $schemaDir === '0' || ! is_dir($schemaDir)) {
+            return;
+        }
+
+        foreach ($this->schemaFiles($schemaDir) as $schemaFile) {
+            $schema = $this->jsonFile->assoc($schemaFile);
+            $schemaName = basename($schemaFile);
+            foreach ($this->schemaProperties($schema) as $pointer => $property) {
+                $this->addUsage($property, sprintf('schema property: %s#%s', $schemaName, $pointer));
+            }
+        }
+    }
+
+    private function addUsage(string $term, string $usage): void
+    {
+        if (str_starts_with($term, '_')) {
+            $this->reservedUsages[$term][$usage] = true;
+
+            return;
+        }
+
+        $this->apiUsages[$term][$usage] = true;
+    }
+
+    private function collectAlpsDescriptors(): void
+    {
+        if ($this->config->alps === '' || $this->config->alps === '0' || ! file_exists($this->config->alps)) {
+            return;
+        }
+
+        if (pathinfo($this->config->alps, PATHINFO_EXTENSION) === 'json') {
+            $profile = $this->jsonFile->assoc($this->config->alps);
+            $this->collectAlpsDescriptorsFromArray($profile);
+
+            return;
+        }
+
+        $xml = @simplexml_load_file($this->config->alps);
+        if (! $xml instanceof SimpleXMLElement) {
+            return;
+        }
+
+        $this->collectAlpsDescriptorsFromXml($xml);
+    }
+
+    /** @return list<object{uriPath: string, class: class-string}> */
+    private function sortedResourceFiles(): array
+    {
+        $resourceFiles = $this->config->resourceFiles;
+        usort(
+            $resourceFiles,
+            static fn (object $a, object $b): int => [$a->uriPath, $a->class] <=> [$b->uriPath, $b->class],
+        );
+
+        /** @var list<object{uriPath: string, class: class-string}> $resourceFiles */
+        return $resourceFiles;
+    }
+
+    private function isResourceMethod(ReflectionMethod $method): bool
+    {
+        return $method->getName() === 'onGet'
+            || $method->getName() === 'onPut'
+            || $method->getName() === 'onPost'
+            || $method->getName() === 'onPatch'
+            || $method->getName() === 'onDelete';
+    }
+
+    /** @return list<string> */
+    private function schemaFiles(string $schemaDir): array
+    {
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($schemaDir, FilesystemIterator::SKIP_DOTS));
+        /** @var list<string> $files */
+        $files = [];
+        foreach ($iterator as $file) {
+            assert($file instanceof SplFileInfo);
+            $pathname = $file->getPathname();
+            if (is_file($pathname) && str_ends_with($pathname, '.json')) {
+                $files[] = $pathname;
+            }
+        }
+
+        usort($files, static fn (mixed $a, mixed $b): int => [basename((string) $a), (string) $a] <=> [basename((string) $b), (string) $b]);
+
+        return $files;
+    }
+
+    /**
+     * @param array<array-key, mixed> $schema
+     *
+     * @return array<string, string>
+     */
+    private function schemaProperties(array $schema, string $basePointer = ''): array
+    {
+        $properties = [];
+        if (isset($schema['properties']) && is_array($schema['properties'])) {
+            /** @var array<array-key, mixed> $rawProperties */
+            $rawProperties = $schema['properties'];
+            foreach (array_keys($rawProperties) as $name) {
+                $property = (string) $name;
+                $pointer = $basePointer . '/properties/' . $this->jsonPointerToken($property);
+                $properties[$pointer] = $property;
+                if (is_array($rawProperties[$name])) {
+                    $properties += $this->schemaProperties($rawProperties[$name], $pointer);
+                }
+            }
+        }
+
+        foreach ($schema as $key => $value) {
+            if ($key === 'properties' || ! is_array($value)) {
+                continue;
+            }
+
+            /** @var array<array-key, mixed> $schemaValue */
+            $schemaValue = $value;
+            $properties += $this->schemaProperties($schemaValue, $basePointer . '/' . $this->jsonPointerToken((string) $key));
+        }
+
+        ksort($properties);
+
+        return $properties;
+    }
+
+    private function jsonPointerToken(string $token): string
+    {
+        return str_replace(['~', '/'], ['~0', '~1'], $token);
+    }
+
+    /** @param array<array-key, mixed> $node */
+    private function collectAlpsDescriptorsFromArray(array $node): void
+    {
+        if (isset($node['id']) && is_string($node['id'])) {
+            $this->alpsDescriptors[$node['id']] = $this->alpsDescriptorFromArray($node);
+        }
+
+        foreach ($node as $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            /** @var array<array-key, mixed> $value */
+            $this->collectAlpsDescriptorsFromArray($value);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     *
+     * @return AlpsDescriptor
+     */
+    private function alpsDescriptorFromArray(array $node): array
+    {
+        $descriptor = [];
+        if (isset($node['title']) && is_string($node['title']) && $node['title'] !== '') {
+            $descriptor['title'] = $node['title'];
+        }
+
+        if (isset($node['def']) && is_string($node['def']) && $node['def'] !== '') {
+            $descriptor['def'] = $node['def'];
+        }
+
+        $doc = $this->docFromArray($node['doc'] ?? null);
+        if ($doc !== '') {
+            $descriptor['doc'] = $doc;
+        }
+
+        return $descriptor;
+    }
+
+    private function docFromArray(mixed $doc): string
+    {
+        if (is_string($doc)) {
+            return trim($doc);
+        }
+
+        if (is_array($doc) && isset($doc['value']) && is_string($doc['value'])) {
+            return trim($doc['value']);
+        }
+
+        return '';
+    }
+
+    private function collectAlpsDescriptorsFromXml(SimpleXMLElement $node): void
+    {
+        $id = (string) $node['id'];
+        if ($id !== '') {
+            $this->alpsDescriptors[$id] = $this->alpsDescriptorFromXml($node);
+        }
+
+        foreach ($node->children() ?? [] as $child) {
+            /** @var SimpleXMLElement $child */
+            $this->collectAlpsDescriptorsFromXml($child);
+        }
+    }
+
+    /** @return AlpsDescriptor */
+    private function alpsDescriptorFromXml(SimpleXMLElement $node): array
+    {
+        $descriptor = [];
+        $title = (string) $node['title'];
+        if ($title !== '') {
+            $descriptor['title'] = $title;
+        }
+
+        $def = (string) $node['def'];
+        if ($def !== '') {
+            $descriptor['def'] = $def;
+        }
+
+        foreach ($node->children() ?? [] as $child) {
+            if ($child->getName() !== 'doc') {
+                continue;
+            }
+
+            $doc = trim((string) $child);
+            if ($doc !== '') {
+                $descriptor['doc'] = $doc;
+            }
+        }
+
+        return $descriptor;
+    }
+
+    /**
+     * @param array<string, array<string, true>> $apiUsages
+     * @param array<string, AlpsDescriptor>      $alpsDescriptors
+     */
+    private function matchedAlpsDescriptorCount(array $apiUsages, array $alpsDescriptors): int
+    {
+        $count = 0;
+        foreach (array_keys($apiUsages) as $term) {
+            if (array_key_exists($term, $alpsDescriptors)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    private function coveragePercent(int $total, int $matched): string
+    {
+        if ($total === 0) {
+            return '0';
+        }
+
+        $coverage = round((float) $matched / (float) $total * 100.0, 1);
+
+        return sprintf('%g', $coverage);
+    }
+}

--- a/tests/ApiDocAuditTest.php
+++ b/tests/ApiDocAuditTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use PHPUnit\Framework\TestCase;
+
+use function strpos;
+
+final class ApiDocAuditTest extends TestCase
+{
+    public function testGenerateMarkdownReportsSummaryAndFindings(): void
+    {
+        $report = (new ApiDocAudit(new Config(__DIR__ . '/apidoc.alps.xml')))->generateMarkdown();
+
+        $this->assertStringContainsString('# API Documentation Audit', $report);
+        $this->assertMatchesRegularExpression('/- Resources: \d+/', $report);
+        $this->assertStringContainsString('- Operations: 28', $report);
+        $this->assertStringContainsString('- Operations with response schema: 11', $report);
+        $this->assertStringContainsString('- Operations with request schema: 12', $report);
+        $this->assertStringContainsString('- Operations with ALPS attributes: 6', $report);
+
+        $this->assertStringContainsString("### POST /contact\n- Missing response schema.\n- Missing request schema for non-path body input.\n- Missing resource class summary.\n- Missing operation summary.\n- Missing ALPS attribute.", $report);
+        $this->assertStringContainsString("### PATCH /person\n- Missing response schema.\n- Missing ALPS attribute.", $report);
+        $this->assertStringContainsString("### GET /tickets\n- Missing resource class summary.\n- Missing operation summary.\n- Missing ALPS attribute.", $report);
+    }
+
+    public function testGenerateMarkdownOrdersOperationsByPathAndMethod(): void
+    {
+        $report = (new ApiDocAudit(new Config(__DIR__ . '/apidoc.alps.xml')))->generateMarkdown();
+
+        $address = strpos($report, '### GET /address');
+        $contact = strpos($report, '### POST /contact');
+        $personPatch = strpos($report, '### PATCH /person');
+        $personPost = strpos($report, '### POST /person');
+        $ticketDelete = strpos($report, '### DELETE /ticket/{id}');
+        $ticketGet = strpos($report, '### GET /ticket/{id}');
+
+        $this->assertIsInt($address);
+        $this->assertIsInt($contact);
+        $this->assertIsInt($personPatch);
+        $this->assertIsInt($personPost);
+        $this->assertIsInt($ticketDelete);
+        $this->assertIsInt($ticketGet);
+        $this->assertLessThan($contact, $address);
+        $this->assertLessThan($personPost, $personPatch);
+        $this->assertLessThan($ticketGet, $ticketDelete);
+    }
+
+    public function testAlpsCountsAndFindingsAreOnlyReportedWhenProfileIsConfigured(): void
+    {
+        $report = (new ApiDocAudit(new Config(__DIR__ . '/apidoc.html.xml')))->generateMarkdown();
+
+        $this->assertStringNotContainsString('Operations with ALPS attributes', $report);
+        $this->assertStringNotContainsString('Missing ALPS attribute.', $report);
+    }
+
+    public function testAlpsStringZeroIsTreatedAsDisabled(): void
+    {
+        $config = TestConfigFactory::new([
+            'alps' => '0',
+            'resourceFiles' => [(object) ['uriPath' => 'no-alps', 'class' => NoAlpsAuditResource::class]],
+            'routes' => ['no-alps' => '/no-alps/{id}'],
+        ]);
+        $report = (new ApiDocAudit($config))->generateMarkdown();
+
+        $this->assertStringNotContainsString('Operations with ALPS attributes', $report);
+        $this->assertStringNotContainsString('Missing ALPS attribute.', $report);
+        $this->assertStringContainsString("## Findings\nNo documentation gaps found.", $report);
+    }
+
+    public function testGenerateMarkdownReportsNoFindingsForDocumentedOperations(): void
+    {
+        $config = TestConfigFactory::new([
+            'alps' => __FILE__,
+            'resourceFiles' => [(object) ['uriPath' => 'documented', 'class' => DocumentedAuditResource::class]],
+            'routes' => ['documented' => '/documented/{id}'],
+        ]);
+        $report = (new ApiDocAudit($config))->generateMarkdown();
+
+        $this->assertStringContainsString('- Resources: 1', $report);
+        $this->assertStringContainsString('- Operations: 1', $report);
+        $this->assertStringContainsString('- Operations with response schema: 1', $report);
+        $this->assertStringContainsString('- Operations with request schema: 1', $report);
+        $this->assertStringContainsString('- Operations with ALPS attributes: 1', $report);
+        $this->assertStringContainsString("## Findings\nNo documentation gaps found.", $report);
+        $this->assertStringNotContainsString('Missing ', $report);
+    }
+
+    public function testClassLevelAlpsAttributeCountsAsOperationAlpsCoverage(): void
+    {
+        $config = TestConfigFactory::new([
+            'alps' => __FILE__,
+            'resourceFiles' => [(object) ['uriPath' => 'class-level-alps', 'class' => ClassLevelAlpsAuditResource::class]],
+            'routes' => ['class-level-alps' => '/class-level-alps/{id}'],
+        ]);
+        $report = (new ApiDocAudit($config))->generateMarkdown();
+
+        $this->assertStringContainsString('- Operations with ALPS attributes: 1', $report);
+        $this->assertStringContainsString("## Findings\nNo documentation gaps found.", $report);
+        $this->assertStringNotContainsString('Missing ALPS attribute.', $report);
+    }
+}

--- a/tests/ApiDocTest.php
+++ b/tests/ApiDocTest.php
@@ -133,6 +133,34 @@ class ApiDocTest extends TestCase
         $this->assertStringContainsString('## ResourceObjects', $content);
     }
 
+    public function testAuditOutput(): void
+    {
+        $apiDoc = new ApiDoc();
+        $result = $apiDoc(__DIR__ . '/apidoc.audit.xml');
+
+        $this->assertStringContainsString('audit.md', $result);
+        $this->assertFileExists(__DIR__ . '/docs/audit/audit.md');
+
+        $content = file_get_contents(__DIR__ . '/docs/audit/audit.md');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('# API Documentation Audit', $content);
+        $this->assertStringContainsString('## Findings', $content);
+    }
+
+    public function testTermsOutput(): void
+    {
+        $apiDoc = new ApiDoc();
+        $result = $apiDoc(__DIR__ . '/apidoc.terms.xml');
+
+        $this->assertStringContainsString('terms.md', $result);
+        $this->assertFileExists(__DIR__ . '/docs/terms/terms.md');
+
+        $content = file_get_contents(__DIR__ . '/docs/terms/terms.md');
+        $this->assertIsString($content);
+        $this->assertStringContainsString('# Term Usage Index', $content);
+        $this->assertStringContainsString('Lexical ALPS coverage', $content);
+    }
+
     public function testMultipleFormatsOutput(): void
     {
         $apiDoc = new ApiDoc();

--- a/tests/ClassLevelAlpsAuditResource.php
+++ b/tests/ClassLevelAlpsAuditResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\ApiDoc\Annotation\Alps;
+use BEAR\Resource\Annotation\JsonSchema;
+
+/** Class-level ALPS resource used to exercise audit ALPS coverage. */
+#[Alps('classLevelDocumented')]
+final class ClassLevelAlpsAuditResource
+{
+    /**
+     * Gets a class-level documented resource.
+     */
+    #[JsonSchema(schema: 'documented.json')]
+    public function onGet(string $id): void
+    {
+    }
+}

--- a/tests/DocumentedAuditResource.php
+++ b/tests/DocumentedAuditResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\ApiDoc\Annotation\Alps;
+use BEAR\Resource\Annotation\JsonSchema;
+
+/** Documented resource used to exercise the no-findings audit path. */
+final class DocumentedAuditResource
+{
+    /**
+     * Updates a documented resource.
+     */
+    #[Alps('documented')]
+    #[JsonSchema(schema: 'documented.json', params: 'documented.param.json')]
+    public function onPut(string $id, string $name): void
+    {
+    }
+}

--- a/tests/FakeDataExampleResolverTest.php
+++ b/tests/FakeDataExampleResolverTest.php
@@ -149,6 +149,30 @@ final class FakeDataExampleResolverTest extends TestCase
         $this->assertSame(['title' => 'Hello'], $this->readJson('docs/examples/create.param.json'));
     }
 
+    public function testRequestProjectionUsesFirstObjectFromListPayload(): void
+    {
+        $this->writeJson('fake/article.json', [['title' => 'Hello', 'extra' => true]]);
+        $resolver = $this->resolver();
+        $example = $resolver->requestExample(
+            'article.param.json',
+            $this->schema('article.param.json', 'object', ['title']),
+            '',
+            ['title'],
+        );
+
+        $this->assertInstanceOf(FakeDataExample::class, $example);
+        $this->assertSame('./examples/article.param.json', $example->externalValue);
+        $this->assertSame(['title' => 'Hello'], $this->readJson('docs/examples/article.param.json'));
+    }
+
+    public function testExternalValueRelativeToBaseDirectory(): void
+    {
+        $example = new FakeDataExample('ArticleFake', 'summary', './fake/article.json');
+
+        $this->assertSame('./fake/article.json', $example->externalValueRelativeTo(''));
+        $this->assertSame('./fake/article.json', $example->externalValueRelativeTo('.'));
+    }
+
     public function testUnsupportedResponseAndRequestPayloadsAreSkipped(): void
     {
         $resolver = $this->resolver();

--- a/tests/HtmlRendererTest.php
+++ b/tests/HtmlRendererTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+final class HtmlRendererTest extends TestCase
+{
+    public function testUnknownExampleLinkKindsAreIgnored(): void
+    {
+        $method = new ReflectionMethod(HtmlRenderer::class, 'renderExampleLinks');
+
+        $this->assertSame('', $method->invoke(
+            new HtmlRenderer(),
+            ['other' => ['href' => 'examples/article.json', 'label' => 'Other']],
+        ));
+    }
+}

--- a/tests/JsonSchemaTest.php
+++ b/tests/JsonSchemaTest.php
@@ -129,6 +129,17 @@ class JsonSchemaTest extends TestCase
         $this->assertStringContainsString('TKT-001', $jsonSchema->examples[0]);
     }
 
+    public function testPropertySchemasSkipsNonObjectProperties(): void
+    {
+        $jsonSchema = new Schema(
+            new SplFileInfo(__FILE__),
+            (object) ['type' => 'array', 'properties' => ['id' => 'string']],
+            new ArrayObject()
+        );
+
+        $this->assertSame([], $jsonSchema->propertySchemas());
+    }
+
     public function testSchemaPropertyWithExample(): void
     {
         $jsonFile = __DIR__ . '/Fake/app/docs/base/schema/ticket.json';

--- a/tests/NoAlpsAuditResource.php
+++ b/tests/NoAlpsAuditResource.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use BEAR\Resource\Annotation\JsonSchema;
+
+/** Resource without ALPS used to exercise disabled ALPS audit paths. */
+final class NoAlpsAuditResource
+{
+    /**
+     * Gets a documented resource without ALPS.
+     */
+    #[JsonSchema(schema: 'documented.json')]
+    public function onGet(string $id): void
+    {
+    }
+}

--- a/tests/TermUsageIndexTest.php
+++ b/tests/TermUsageIndexTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use PHPUnit\Framework\TestCase;
+
+use function str_replace;
+
+final class TermUsageIndexTest extends TestCase
+{
+    private string $markdown;
+
+    protected function setUp(): void
+    {
+        $config = new Config(__DIR__ . '/apidoc.xml');
+        $this->markdown = (new TermUsageIndex($config))->generateMarkdown();
+    }
+
+    public function testParameterUsagesFromResourceMethodsAndInputExpansion(): void
+    {
+        $this->assertStringContainsString('### Term: `firstName`', $this->markdown);
+        $this->assertStringContainsString('- parameter: POST /person {firstName}', $this->markdown);
+        $this->assertStringContainsString('- parameter: PATCH /person {familyName}', $this->markdown);
+        $this->assertStringContainsString('- parameter: POST /contact {name}', $this->markdown);
+    }
+
+    public function testSchemaPropertyUsagesFromConfiguredSchemaDirs(): void
+    {
+        $this->assertStringContainsString('- schema property: person.json#/properties/firstName', $this->markdown);
+        $this->assertStringContainsString('- schema property: person.param.json#/properties/familyName', $this->markdown);
+    }
+
+    public function testAlpsDescriptorLexicalMatchesAndSummary(): void
+    {
+        $markdown = self::normalizeNewlines($this->markdown);
+
+        $this->assertStringContainsString('This index reports lexical identifier matches only; it does not prove semantic equivalence.', $markdown);
+        $this->assertStringContainsString('- Terms used in API:', $markdown);
+        $this->assertStringContainsString('- Terms with same-name ALPS descriptor:', $markdown);
+        $this->assertStringContainsString('- Lexical ALPS coverage:', $markdown);
+        $this->assertStringContainsString('- Reserved representation fields:', $markdown);
+        $this->assertStringContainsString('- ☑︎ = ALPS descriptor binding', $markdown);
+        $this->assertStringContainsString("### Term: `firstName` ☑︎\n\n- title: firstName by ALPS", $markdown);
+        $this->assertStringContainsString("### Term: `familyName` ☑︎\n\n- def: https://schema.org/familyName", $markdown);
+        $this->assertStringContainsString("### Term: `age` ☑︎\n\n- doc: Age in years which must be equal to or greater than zero.", $markdown);
+        $this->assertStringContainsString("### Term: `foo` ☑︎\n\n- doc: Foo descriptor", $markdown);
+        $this->assertStringContainsString("### Term: `assignee`\n\n- usages:", $markdown);
+    }
+
+    public function testReservedRepresentationFieldsAreSeparatedFromApiTerms(): void
+    {
+        $markdown = self::normalizeNewlines($this->markdown);
+
+        $this->assertStringContainsString('- Reserved representation fields: 2', $markdown);
+        $this->assertStringNotContainsString('### Term: `_embedded`', $markdown);
+        $this->assertStringNotContainsString('### Term: `_links`', $markdown);
+        $this->assertStringContainsString("## Reserved Representation Fields\n\nLeading-underscore fields are listed separately", $markdown);
+        $this->assertStringContainsString("### Field: `_embedded`\n\n- usages:\n  - schema property: user.json#/properties/_embedded", $markdown);
+        $this->assertStringContainsString("### Field: `_links`\n\n- usages:\n  - schema property: user.json#/properties/_links", $markdown);
+    }
+
+    public function testMarkdownIsDeterministic(): void
+    {
+        $config = new Config(__DIR__ . '/apidoc.xml');
+
+        $this->assertSame($this->markdown, (new TermUsageIndex($config))->generateMarkdown());
+    }
+
+    public function testMissingInputsProduceEmptySummary(): void
+    {
+        $markdown = (new TermUsageIndex(TestConfigFactory::new()))->generateMarkdown();
+
+        $this->assertStringContainsString('- Terms used in API: 0', $markdown);
+        $this->assertStringContainsString('- Terms with same-name ALPS descriptor: 0', $markdown);
+        $this->assertStringContainsString('- Lexical ALPS coverage: 0%', $markdown);
+        $this->assertStringContainsString('- Reserved representation fields: 0', $markdown);
+        $this->assertStringNotContainsString('### Term:', $markdown);
+        $this->assertStringNotContainsString('## Reserved Representation Fields', $markdown);
+    }
+
+    public function testXmlAlpsDescriptorsAreMatchedLexically(): void
+    {
+        $config = TestConfigFactory::new([
+            'alps' => __DIR__ . '/term-usage.alps.xml',
+            'resourceFiles' => [(object) ['uriPath' => 'xml-term', 'class' => XmlTermResource::class]],
+            'routes' => ['xml-term' => '/xml-term/{id}'],
+        ]);
+        $markdown = (new TermUsageIndex($config))->generateMarkdown();
+
+        $this->assertStringContainsString('### Term: `id` ☑︎', $markdown);
+        $this->assertStringContainsString('- title: Identifier', $markdown);
+        $this->assertStringContainsString('- def: https://schema.org/identifier', $markdown);
+        $this->assertStringContainsString('- doc: Identifier.', $markdown);
+        $this->assertStringContainsString('- parameter: GET /xml-term/{id} {id}', $markdown);
+    }
+
+    public function testInvalidXmlAlpsProfileIsIgnored(): void
+    {
+        $config = TestConfigFactory::new([
+            'alps' => __DIR__ . '/invalid-alps.xml',
+        ]);
+        $markdown = (new TermUsageIndex($config))->generateMarkdown();
+
+        $this->assertStringContainsString('- Terms used in API: 0', $markdown);
+        $this->assertStringContainsString('- Terms with same-name ALPS descriptor: 0', $markdown);
+    }
+
+    private static function normalizeNewlines(string $text): string
+    {
+        return str_replace("\r\n", "\n", $text);
+    }
+}

--- a/tests/TestConfigFactory.php
+++ b/tests/TestConfigFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use ReflectionClass;
+
+use function array_replace;
+
+final class TestConfigFactory
+{
+    /** @param array<string, mixed> $overrides */
+    public static function new(array $overrides = []): Config
+    {
+        $reflection = new ReflectionClass(Config::class);
+        $config = $reflection->newInstanceWithoutConstructor();
+        $defaults = [
+            'appName' => 'FakeVendor\FakeProject',
+            'scheme' => 'app',
+            'docDir' => __DIR__ . '/docs',
+            'formats' => [],
+            'title' => '',
+            'description' => '',
+            'links' => [],
+            'alps' => '',
+            'resourceFiles' => [],
+            'modelRepository' => new ModelRepository(),
+            'routes' => [],
+            'requestSchemaDir' => '',
+            'responseSchemaDir' => '',
+            'fakeDataDir' => '',
+            'queryClasses' => [],
+            'sqlDir' => '',
+        ];
+
+        foreach (array_replace($defaults, $overrides) as $name => $value) {
+            $reflection->getProperty($name)->setValue($config, $value);
+        }
+
+        return $config;
+    }
+}

--- a/tests/XmlTermResource.php
+++ b/tests/XmlTermResource.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+final class XmlTermResource
+{
+    public function onGet(string $id): void
+    {
+    }
+}

--- a/tests/apidoc.audit.xml
+++ b/tests/apidoc.audit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../apidoc.xsd">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>docs/audit</docDir>
+    <format>audit</format>
+    <title>API Doc Title</title>
+    <description>This is the description of API Doc</description>
+    <alps>Fake/app/alps.json</alps>
+</apidoc>

--- a/tests/apidoc.demo-audit.xml
+++ b/tests/apidoc.demo-audit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../apidoc.xsd">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>../docs</docDir>
+    <format>audit</format>
+    <title>API Documentation Audit</title>
+    <description>Documentation coverage report for the demo API</description>
+    <alps>../docs/alps.json</alps>
+</apidoc>

--- a/tests/apidoc.demo-terms.xml
+++ b/tests/apidoc.demo-terms.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../apidoc.xsd">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>../docs</docDir>
+    <format>terms</format>
+    <title>Term Usage Index</title>
+    <description>Term usage index for the demo API</description>
+    <alps>../docs/alps.json</alps>
+</apidoc>

--- a/tests/apidoc.html.xml
+++ b/tests/apidoc.html.xml
@@ -14,5 +14,7 @@
         <link rel="profile" href="alps/" />
         <link rel="openapi" href="openapi/openapi.json" />
         <link rel="openapi-html" href="openapi/" />
+        <link rel="audit" href="audit.md" />
+        <link rel="terms" href="terms.md" />
     </links>
 </apidoc>

--- a/tests/apidoc.terms.xml
+++ b/tests/apidoc.terms.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<apidoc
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="../apidoc.xsd">
+    <appName>FakeVendor\FakeProject</appName>
+    <scheme>app</scheme>
+    <docDir>docs/terms</docDir>
+    <format>terms</format>
+    <title>API Doc Title</title>
+    <description>This is the description of API Doc</description>
+    <alps>profile.json</alps>
+</apidoc>

--- a/tests/invalid-alps.xml
+++ b/tests/invalid-alps.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alps>

--- a/tests/profile.json
+++ b/tests/profile.json
@@ -5,7 +5,7 @@
       {"id": "firstName", "title": "firstName by ALPS"},
       {"id": "familyName", "def": "https://schema.org/familyName"},
       {"id": "age", "doc": {"value": "Age in years which must be equal to or greater than zero."}},
-      {"id": "foo"}
+      {"id": "foo", "doc": "Foo descriptor"}
     ]
   }
 }

--- a/tests/term-usage.alps.xml
+++ b/tests/term-usage.alps.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alps version="1.0">
+  <descriptor id="id" title="Identifier" def="https://schema.org/identifier">
+    <descriptor id="nested"/>
+    <doc format="text">Identifier.</doc>
+  </descriptor>
+</alps>


### PR DESCRIPTION
## Summary
- Add `audit` output support and `apidoc audit` for Markdown documentation coverage reports
- Add `terms` output support and `apidoc terms` for lexical Term Usage Index reports
- Document the new report formats and cover them with focused tests and integration generation tests

## Verification
- `composer tests`
