### PR TITLE
Add 1.11.0 release notes to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-06-03
+
 ### Added
 - Add `audit` output format and `apidoc audit` command for documentation coverage reports.
 - Add `terms` output format and `apidoc terms` command for lexical Term Usage Index reports.
+- Generate a `terms.html` companion Term Usage Index with HTML docs and `terms.md` with
+  Markdown docs, linked automatically from `index.html` / `index.md` (#94).
+- Render the HTML Term Usage Index as ALPS-profile-semantic markup: terms defined in ALPS
+  carry their descriptor id as `class` and are flagged, descriptors are shown as labelled
+  `title`/`def`/`doc` attributes, with an in-page Index for navigation (#94).
 
 ## [1.10.0] - 2026-05-17
 
@@ -146,7 +153,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update dependencies
 
-[Unreleased]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.10.0...HEAD
+[Unreleased]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.11.0...HEAD
+[1.11.0]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.10.0...1.11.0
 [1.10.0]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.2...1.10.0
 [1.9.2]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.1...1.9.2
 [1.9.1]: https://github.com/bearsunday/BEAR.ApiDoc/compare/1.9.0...1.9.1


### PR DESCRIPTION
## Summary

Lands the **1.11.0** release notes in `CHANGELOG.md`. The 1.11.0 entry was cut just after #94 was merged, so it did not ride along with that merge — this is the changelog-only follow-up. The feature code from #94 is already on `1.x`.

This is the changelog gate before tagging `1.11.0`:
- Cut `[Unreleased]` → `[1.11.0] - 2026-06-02` (audit/terms output formats + the Term Usage Index companion `terms.html` / `terms.md`, profile-semantic markup, in-page Index).
- Update the compare links (`[1.11.0]`, `[Unreleased]` rebased on 1.11.0).

Diff is `CHANGELOG.md` only.

## Next steps after merge

1. Tag `1.11.0` on `1.x`.
2. Create the GitHub Release for `1.11.0` (notes = the 1.11.0 CHANGELOG section).

---
_Generated by [Claude Code](https://claude.ai/code/session_014Cjmit35NKkrmGeAhqzbBX)_