### PR TITLE
Give the Term Usage Index its own ALPS profile

### DIFF
--- a/docs/alps/terms.xml
+++ b/docs/alps/terms.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<alps version="1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="https://alps-io.github.io/schemas/alps.xsd">
+
+  <title>BEAR.ApiDoc Term Usage Index Profile</title>
+  <doc format="markdown">
+This profile describes the vocabulary of the Term Usage Index page (terms.html) itself, not the API it indexes.
+
+The Term Usage Index is a meta-document: it lists the identifiers (parameter names and JSON Schema property names) that appear across the generated API documentation and records where each one is used. Because it talks *about* the documentation's vocabulary, its profile sits one level above the API profile (apidoc.xml) and above any application-level ALPS profile (which defines the domain meaning of terms such as `age` or `familyName`).
+
+Bind page elements to these descriptors by their `class` attribute:
+- a term entry carries `class="term"` (and `class="term alpsBacked"` when a same-name descriptor exists in the configured application ALPS profile);
+- the cross-reference to that application descriptor, when present, is carried by the `data-alps` attribute, not by `class`;
+- usage occurrences carry `class="usage"`, refined to `parameterUsage` or `schemaPropertyUsage`;
+- reserved representation fields carry `class="reservedField"`;
+- summary figures carry the matching count/coverage descriptor classes.
+
+Matching is lexical (same identifier spelling); it does not assert semantic equivalence between the indexed term and the application descriptor.
+  </doc>
+  <link rel="help" href="https://alps-io.github.io/spec/"/>
+
+  <!-- The document as a whole -->
+
+  <descriptor id="termUsageIndex" type="semantic" title="Term Usage Index">
+    <doc>The index document. Lists every identifier used in the generated API documentation and where it appears. A companion view to the main API documentation (index.html), one meta level above it.</doc>
+  </descriptor>
+
+  <!-- Term entries -->
+
+  <descriptor id="term" type="semantic" title="Indexed Term">
+    <doc>An identifier used in the API: a request parameter name or a JSON Schema property name. The entry collects every place the identifier appears. Listing is by lexical spelling, so the same spelling used in unrelated places is collected under one entry.</doc>
+  </descriptor>
+
+  <descriptor id="alpsBacked" type="semantic" title="ALPS-backed Term">
+    <doc>Marks a term whose spelling also exists as a descriptor id in the configured application ALPS profile (the `alps` setting in apidoc.xml). Shown with a checkmark. This is a lexical match only and does not prove that the indexed term and the application descriptor mean the same thing. The application descriptor id is exposed on the entry's `data-alps` attribute for cross-reference.</doc>
+  </descriptor>
+
+  <descriptor id="borrowedDescriptor" type="semantic" title="Borrowed Descriptor Detail">
+    <doc>Descriptor metadata (title, def, doc) shown on an ALPS-backed entry. The value is borrowed from the configured application ALPS profile for display; this index is not its authority. A `def` that is a URL links to the external vocabulary it references.</doc>
+  </descriptor>
+
+  <!-- Usage occurrences -->
+
+  <descriptor id="usage" type="semantic" title="Usage Occurrence">
+    <doc>One place where the term appears in the API documentation.</doc>
+    <descriptor id="parameterUsage" type="semantic" title="Parameter Usage">
+      <doc>The term is used as a request parameter of an endpoint, written as "parameter: METHOD /path {term}". Extracted from the resource method signature.</doc>
+    </descriptor>
+    <descriptor id="schemaPropertyUsage" type="semantic" title="Schema Property Usage">
+      <doc>The term is used as a JSON Schema property, written as "schema property: file.json#/json/pointer". Extracted from request and response schema files.</doc>
+    </descriptor>
+  </descriptor>
+
+  <descriptor id="reservedField" type="semantic" title="Reserved Representation Field">
+    <doc>A leading-underscore field such as `_links` or `_embedded`. Listed separately because it usually belongs to the representation format (HAL) rather than the API domain vocabulary.</doc>
+  </descriptor>
+
+  <!-- Summary figures -->
+
+  <descriptor id="termsUsedCount" type="semantic" title="Terms Used Count">
+    <doc>Number of distinct API terms collected (excluding reserved representation fields).</doc>
+  </descriptor>
+
+  <descriptor id="alpsMatchedCount" type="semantic" title="ALPS-matched Count">
+    <doc>Number of collected terms whose spelling matches a descriptor id in the configured application ALPS profile.</doc>
+  </descriptor>
+
+  <descriptor id="lexicalCoverage" type="semantic" title="Lexical ALPS Coverage">
+    <doc>alpsMatchedCount divided by termsUsedCount, as a percentage. A lexical coverage figure, not a semantic one.</doc>
+  </descriptor>
+
+  <descriptor id="reservedCount" type="semantic" title="Reserved Field Count">
+    <doc>Number of distinct reserved representation fields collected.</doc>
+  </descriptor>
+
+</alps>

--- a/docs/alps/terms.xml
+++ b/docs/alps/terms.xml
@@ -14,7 +14,10 @@ Bind page elements to these descriptors by their `class` attribute:
 - the cross-reference to that application descriptor, when present, is carried by the `data-alps` attribute, not by `class`;
 - usage occurrences carry `class="usage"`, refined to `parameterUsage` or `schemaPropertyUsage`;
 - reserved representation fields carry `class="reservedField"`;
-- summary figures carry the matching count/coverage descriptor classes.
+- summary figures carry the matching count/coverage descriptor classes;
+- the whole document is bound by `class="termUsageIndex"` on its `main` element.
+
+Representation and navigation chrome is deliberately outside this vocabulary and carries no descriptor binding: the "API Documentation" back link, the `index-list` table of contents, and the `mark` checkmark are presentation only. Their absence from the binding set is intentional, not an omission.
 
 Matching is lexical (same identifier spelling); it does not assert semantic equivalence between the indexed term and the application descriptor.
   </doc>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -75,7 +75,7 @@ dd ul {
 </style>
 </head>
 <body>
-<main>
+<main class="termUsageIndex">
 <p><a href="index.html">API Documentation</a></p>
 <h1>Term Usage Index</h1>
 <p>This index reports lexical identifier matches only; it does not prove semantic equivalence. Its own vocabulary (term, alpsBacked, usage, reservedField, coverage) is defined by the profile linked above. A term whose spelling also exists in the configured application ALPS profile is marked <code>alpsBacked</code>; the matched application descriptor id is carried on the entry's <code>data-alps</code> attribute.</p>

--- a/docs/terms.html
+++ b/docs/terms.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Term Usage Index</title>
-<link rel="profile" href="https://bearsunday.github.io/BEAR.ApiDoc/alps/apidoc.xml">
+<link rel="profile" href="https://bearsunday.github.io/BEAR.ApiDoc/alps/terms.xml">
 <style>
 body {
     margin: 0;
@@ -42,7 +42,7 @@ dt code {
     font-size: 1.2em;
     font-weight: 600;
 }
-.alps {
+.mark {
     margin-left: 6px;
     color: #1a7f37;
 }
@@ -78,174 +78,174 @@ dd ul {
 <main>
 <p><a href="index.html">API Documentation</a></p>
 <h1>Term Usage Index</h1>
-<p>This index reports lexical identifier matches only; it does not prove semantic equivalence. A term backed by an ALPS descriptor carries that descriptor as its class, per the profile linked above.</p>
+<p>This index reports lexical identifier matches only; it does not prove semantic equivalence. Its own vocabulary (term, alpsBacked, usage, reservedField, coverage) is defined by the profile linked above. A term whose spelling also exists in the configured application ALPS profile is marked <code>alpsBacked</code>; the matched application descriptor id is carried on the entry's <code>data-alps</code> attribute.</p>
 
 <h2>Summary</h2>
 <ul>
-  <li>Terms used in API: 73</li>
-  <li>Terms with same-name ALPS descriptor: 4</li>
-  <li>Lexical ALPS coverage: 5.5%</li>
-  <li>Reserved representation fields: 2</li>
+  <li class="termsUsedCount">Terms used in API: 73</li>
+  <li class="alpsMatchedCount">Terms with same-name ALPS descriptor: 4</li>
+  <li class="lexicalCoverage">Lexical ALPS coverage: 5.5%</li>
+  <li class="reservedCount">Reserved representation fields: 2</li>
 </ul>
 
 <h2>Index</h2>
 <ul class="index-list"><li><a href="#term-additionalName">additionalName</a></li><li><a href="#term-age">age</a></li><li><a href="#term-assignee">assignee</a></li><li><a href="#term-bday">bday</a></li><li><a href="#term-bothSummaryAndDescription">bothSummaryAndDescription</a></li><li><a href="#term-builtinType">builtinType</a></li><li><a href="#term-category">category</a></li><li><a href="#term-count">count</a></li><li><a href="#term-country-name">country-name</a></li><li><a href="#term-created">created</a></li><li><a href="#term-date">date</a></li><li><a href="#term-description">description</a></li><li><a href="#term-docOnly">docOnly</a></li><li><a href="#term-dtend">dtend</a></li><li><a href="#term-dtstart">dtstart</a></li><li><a href="#term-duration">duration</a></li><li><a href="#term-email">email</a></li><li><a href="#term-enabled">enabled</a></li><li><a href="#term-extended-address">extended-address</a></li><li><a href="#term-familyName">familyName</a></li><li><a href="#term-firstName">firstName</a></li><li><a href="#term-fn">fn</a></li><li><a href="#term-foo">foo</a></li><li><a href="#term-fruits">fruits</a></li><li><a href="#term-givenName">givenName</a></li><li><a href="#term-honorificPrefix">honorificPrefix</a></li><li><a href="#term-honorificSuffix">honorificSuffix</a></li><li><a href="#term-href">href</a></li><li><a href="#term-id">id</a></li><li><a href="#term-ids">ids</a></li><li><a href="#term-items">items</a></li><li><a href="#term-juice">juice</a></li><li><a href="#term-juiceLike">juiceLike</a></li><li><a href="#term-juiceName">juiceName</a></li><li><a href="#term-lastName">lastName</a></li><li><a href="#term-locality">locality</a></li><li><a href="#term-location">location</a></li><li><a href="#term-logo">logo</a></li><li><a href="#term-modified">modified</a></li><li><a href="#term-name">name</a></li><li><a href="#term-nickname">nickname</a></li><li><a href="#term-noCtor">noCtor</a></li><li><a href="#term-nonPromoted">nonPromoted</a></li><li><a href="#term-options">options</a></li><li><a href="#term-org">org</a></li><li><a href="#term-organizationName">organizationName</a></li><li><a href="#term-organizationUnit">organizationUnit</a></li><li><a href="#term-photo">photo</a></li><li><a href="#term-post-office-box">post-office-box</a></li><li><a href="#term-postal-code">postal-code</a></li><li><a href="#term-priority">priority</a></li><li><a href="#term-rdate">rdate</a></li><li><a href="#term-region">region</a></li><li><a href="#term-role">role</a></li><li><a href="#term-rrule">rrule</a></li><li><a href="#term-self">self</a></li><li><a href="#term-sound">sound</a></li><li><a href="#term-status">status</a></li><li><a href="#term-street-address">street-address</a></li><li><a href="#term-subject">subject</a></li><li><a href="#term-summary">summary</a></li><li><a href="#term-tagOnly">tagOnly</a></li><li><a href="#term-tel">tel</a></li><li><a href="#term-tickets">tickets</a></li><li><a href="#term-title">title</a></li><li><a href="#term-type">type</a></li><li><a href="#term-tz">tz</a></li><li><a href="#term-updated">updated</a></li><li><a href="#term-url">url</a></li><li><a href="#term-value">value</a></li><li><a href="#term-vegetables">vegetables</a></li><li><a href="#term-veggieLike">veggieLike</a></li><li><a href="#term-veggieName">veggieName</a></li><li><a href="#field-_embedded">_embedded</a></li><li><a href="#field-_links">_links</a></li></ul>
 <h2>Terms</h2>
 <dl>
-<dt id="term-additionalName"><code>additionalName</code></dt>
-<dd><ul><li>schema property: card.json#/properties/additionalName</li></ul></dd>
-<dt id="term-age" class="age"><code>age</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>
-<dd><p>title: Age in years which must be equal to or greater than zero.</p><ul><li>parameter: GET /alps-fallback {age}</li><li>parameter: POST /contact {age}</li><li>parameter: POST /contact-with-descriptions {age}</li><li>parameter: POST /person {age}</li><li>parameter: PATCH /person {age}</li><li>parameter: POST /users/{id} {age}</li><li>parameter: PUT /users/{id} {age}</li><li>schema property: contact.param.json#/properties/age</li><li>schema property: person.json#/properties/age</li><li>schema property: person.param.json#/properties/age</li><li>schema property: user.json#/properties/age</li><li>schema property: user.param.json#/properties/age</li></ul></dd>
-<dt id="term-assignee"><code>assignee</code></dt>
-<dd><ul><li>parameter: POST /ticket/{id} {assignee}</li><li>parameter: PUT /ticket/{id} {assignee}</li><li>parameter: PUT /ticket/assign {assignee}</li><li>schema property: ticket.json#/properties/assignee</li><li>schema property: ticket.param.json#/properties/assignee</li></ul></dd>
-<dt id="term-bday"><code>bday</code></dt>
-<dd><ul><li>schema property: card.json#/properties/bday</li></ul></dd>
-<dt id="term-bothSummaryAndDescription"><code>bothSummaryAndDescription</code></dt>
-<dd><ul><li>parameter: POST /docblock-variants {bothSummaryAndDescription}</li></ul></dd>
-<dt id="term-builtinType"><code>builtinType</code></dt>
-<dd><ul><li>parameter: POST /input-edge-cases {builtinType}</li></ul></dd>
-<dt id="term-category"><code>category</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/category</li></ul></dd>
-<dt id="term-count"><code>count</code></dt>
-<dd><ul><li>parameter: GET /numbers {count}</li></ul></dd>
-<dt id="term-country-name"><code>country-name</code></dt>
-<dd><ul><li>schema property: address.json#/properties/country-name</li></ul></dd>
-<dt id="term-created"><code>created</code></dt>
-<dd><ul><li>schema property: ticket.json#/properties/created</li><li>schema property: user.json#/properties/created</li></ul></dd>
-<dt id="term-date"><code>date</code></dt>
-<dd><ul><li>parameter: GET /calendar/{year}/{month} {date}</li></ul></dd>
-<dt id="term-description"><code>description</code></dt>
-<dd><ul><li>parameter: POST /ticket/{id} {description}</li><li>parameter: PUT /ticket/{id} {description}</li><li>schema property: calendar.json#/properties/description</li><li>schema property: ticket.json#/properties/description</li><li>schema property: ticket.param.json#/properties/description</li></ul></dd>
-<dt id="term-docOnly"><code>docOnly</code></dt>
-<dd><ul><li>schema property: json-schema-input.param.json#/properties/docOnly</li></ul></dd>
-<dt id="term-dtend"><code>dtend</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/dtend</li></ul></dd>
-<dt id="term-dtstart"><code>dtstart</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/dtstart</li></ul></dd>
-<dt id="term-duration"><code>duration</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/duration</li></ul></dd>
-<dt id="term-email"><code>email</code></dt>
-<dd><ul><li>parameter: POST /contact {email}</li><li>parameter: POST /contact-with-descriptions {email}</li><li>parameter: POST /users/{id} {email}</li><li>parameter: PUT /users/{id} {email}</li><li>schema property: card.json#/properties/email</li><li>schema property: contact.param.json#/properties/email</li><li>schema property: user.json#/properties/email</li><li>schema property: user.param.json#/properties/email</li></ul></dd>
-<dt id="term-enabled"><code>enabled</code></dt>
-<dd><ul><li>parameter: PUT /users/{id} {enabled}</li><li>schema property: user.json#/properties/enabled</li><li>schema property: user.param.json#/properties/enabled</li></ul></dd>
-<dt id="term-extended-address"><code>extended-address</code></dt>
-<dd><ul><li>schema property: address.json#/properties/extended-address</li></ul></dd>
-<dt id="term-familyName" class="familyName"><code>familyName</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>
-<dd><p>def: <a href="https://schema.org/familyName">https://schema.org/familyName</a></p><ul><li>parameter: GET /alps-fallback {familyName}</li><li>parameter: POST /person {familyName}</li><li>parameter: PATCH /person {familyName}</li><li>schema property: card.json#/properties/familyName</li><li>schema property: person.json#/properties/familyName</li><li>schema property: person.param.json#/properties/familyName</li></ul></dd>
-<dt id="term-firstName" class="firstName"><code>firstName</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>
-<dd><p>title: First Name by ALPS</p><ul><li>parameter: GET /alps-fallback {firstName}</li><li>parameter: POST /person {firstName}</li><li>parameter: PATCH /person {firstName}</li><li>schema property: person.json#/properties/firstName</li><li>schema property: person.param.json#/properties/firstName</li><li>schema property: user.json#/properties/firstName</li></ul></dd>
-<dt id="term-fn"><code>fn</code></dt>
-<dd><ul><li>schema property: card.json#/properties/fn</li></ul></dd>
-<dt id="term-foo"><code>foo</code></dt>
-<dd><ul><li>parameter: GET /alps-fallback {foo}</li></ul></dd>
-<dt id="term-fruits"><code>fruits</code></dt>
-<dd><ul><li>schema property: array.json#/properties/fruits</li></ul></dd>
-<dt id="term-givenName"><code>givenName</code></dt>
-<dd><ul><li>schema property: card.json#/properties/givenName</li></ul></dd>
-<dt id="term-honorificPrefix"><code>honorificPrefix</code></dt>
-<dd><ul><li>schema property: card.json#/properties/honorificPrefix</li></ul></dd>
-<dt id="term-honorificSuffix"><code>honorificSuffix</code></dt>
-<dd><ul><li>schema property: card.json#/properties/honorificSuffix</li></ul></dd>
-<dt id="term-href"><code>href</code></dt>
-<dd><ul><li>schema property: user.json#/properties/_links/properties/self/properties/href</li></ul></dd>
-<dt id="term-id" class="id"><code>id</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>
-<dd><p>title: Person identifier</p><ul><li>parameter: GET /address {id}</li><li>parameter: GET /card {id}</li><li>parameter: GET /org {id}</li><li>parameter: GET /person {id}</li><li>parameter: PATCH /person {id}</li><li>parameter: GET /ticket/{id} {id}</li><li>parameter: PUT /ticket/{id} {id}</li><li>parameter: DELETE /ticket/{id} {id}</li><li>parameter: PUT /ticket/assign {id}</li><li>parameter: GET /union-type {id}</li><li>parameter: GET /users/{id} {id}</li><li>parameter: PUT /users/{id} {id}</li><li>parameter: DELETE /users/{id} {id}</li><li>schema property: org.json#/properties/id</li><li>schema property: person.param.json#/properties/id</li><li>schema property: ticket.json#/properties/id</li><li>schema property: ticket.param.json#/properties/id</li><li>schema property: user.json#/properties/id</li><li>schema property: user.param.json#/properties/id</li></ul></dd>
-<dt id="term-ids"><code>ids</code></dt>
-<dd><ul><li>schema property: json-schema-input.param.json#/properties/ids</li></ul></dd>
-<dt id="term-items"><code>items</code></dt>
-<dd><ul><li>parameter: GET /array-data {items}</li></ul></dd>
-<dt id="term-juice"><code>juice</code></dt>
-<dd><ul><li>schema property: array.json#/properties/juice</li></ul></dd>
-<dt id="term-juiceLike"><code>juiceLike</code></dt>
-<dd><ul><li>schema property: array.json#/definitions/juice/properties/juiceLike</li></ul></dd>
-<dt id="term-juiceName"><code>juiceName</code></dt>
-<dd><ul><li>schema property: array.json#/definitions/juice/properties/juiceName</li></ul></dd>
-<dt id="term-lastName"><code>lastName</code></dt>
-<dd><ul><li>schema property: user.json#/properties/lastName</li></ul></dd>
-<dt id="term-locality"><code>locality</code></dt>
-<dd><ul><li>schema property: address.json#/properties/locality</li></ul></dd>
-<dt id="term-location"><code>location</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/location</li></ul></dd>
-<dt id="term-logo"><code>logo</code></dt>
-<dd><ul><li>schema property: card.json#/properties/logo</li></ul></dd>
-<dt id="term-modified"><code>modified</code></dt>
-<dd><ul><li>schema property: user.json#/properties/modified</li></ul></dd>
-<dt id="term-name"><code>name</code></dt>
-<dd><ul><li>parameter: POST /contact {name}</li><li>parameter: POST /contact-with-descriptions {name}</li><li>parameter: POST /users/{id} {name}</li><li>parameter: PUT /users/{id} {name}</li><li>schema property: contact.param.json#/properties/name</li><li>schema property: org.json#/properties/name</li><li>schema property: user.param.json#/properties/name</li></ul></dd>
-<dt id="term-nickname"><code>nickname</code></dt>
-<dd><ul><li>schema property: card.json#/properties/nickname</li></ul></dd>
-<dt id="term-noCtor"><code>noCtor</code></dt>
-<dd><ul><li>parameter: PUT /input-edge-cases {noCtor}</li></ul></dd>
-<dt id="term-nonPromoted"><code>nonPromoted</code></dt>
-<dd><ul><li>parameter: POST /docblock-variants {nonPromoted}</li></ul></dd>
-<dt id="term-options"><code>options</code></dt>
-<dd><ul><li>parameter: GET /users/{id} {options}</li><li>schema property: user.param.json#/properties/options</li></ul></dd>
-<dt id="term-org"><code>org</code></dt>
-<dd><ul><li>schema property: card.json#/properties/org</li></ul></dd>
-<dt id="term-organizationName"><code>organizationName</code></dt>
-<dd><ul><li>schema property: card.json#/properties/org/properties/organizationName</li></ul></dd>
-<dt id="term-organizationUnit"><code>organizationUnit</code></dt>
-<dd><ul><li>schema property: card.json#/properties/org/properties/organizationUnit</li></ul></dd>
-<dt id="term-photo"><code>photo</code></dt>
-<dd><ul><li>schema property: card.json#/properties/photo</li></ul></dd>
-<dt id="term-post-office-box"><code>post-office-box</code></dt>
-<dd><ul><li>schema property: address.json#/properties/post-office-box</li></ul></dd>
-<dt id="term-postal-code"><code>postal-code</code></dt>
-<dd><ul><li>schema property: address.json#/properties/postal-code</li></ul></dd>
-<dt id="term-priority"><code>priority</code></dt>
-<dd><ul><li>schema property: ticket.json#/properties/priority</li></ul></dd>
-<dt id="term-rdate"><code>rdate</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/rdate</li></ul></dd>
-<dt id="term-region"><code>region</code></dt>
-<dd><ul><li>schema property: address.json#/properties/region</li></ul></dd>
-<dt id="term-role"><code>role</code></dt>
-<dd><ul><li>schema property: card.json#/properties/role</li></ul></dd>
-<dt id="term-rrule"><code>rrule</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/rrule</li></ul></dd>
-<dt id="term-self"><code>self</code></dt>
-<dd><ul><li>schema property: user.json#/properties/_links/properties/self</li></ul></dd>
-<dt id="term-sound"><code>sound</code></dt>
-<dd><ul><li>schema property: card.json#/properties/sound</li></ul></dd>
-<dt id="term-status"><code>status</code></dt>
-<dd><ul><li>parameter: PUT /ticket/{id} {status}</li><li>schema property: json-schema-input.param.json#/properties/status</li><li>schema property: ticket.json#/properties/status</li><li>schema property: ticket.param.json#/properties/status</li></ul></dd>
-<dt id="term-street-address"><code>street-address</code></dt>
-<dd><ul><li>schema property: address.json#/properties/street-address</li></ul></dd>
-<dt id="term-subject"><code>subject</code></dt>
-<dd><ul><li>parameter: POST /contact {subject}</li><li>parameter: POST /contact-with-descriptions {subject}</li><li>schema property: contact.param.json#/properties/subject</li></ul></dd>
-<dt id="term-summary"><code>summary</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/summary</li></ul></dd>
-<dt id="term-tagOnly"><code>tagOnly</code></dt>
-<dd><ul><li>parameter: POST /docblock-variants {tagOnly}</li></ul></dd>
-<dt id="term-tel"><code>tel</code></dt>
-<dd><ul><li>schema property: card.json#/properties/tel</li></ul></dd>
-<dt id="term-tickets"><code>tickets</code></dt>
-<dd><ul><li>schema property: user.json#/properties/_embedded/properties/tickets</li></ul></dd>
-<dt id="term-title"><code>title</code></dt>
-<dd><ul><li>parameter: POST /ticket/{id} {title}</li><li>parameter: PUT /ticket/{id} {title}</li><li>schema property: card.json#/properties/title</li><li>schema property: ticket.json#/properties/title</li><li>schema property: ticket.param.json#/properties/title</li></ul></dd>
-<dt id="term-type"><code>type</code></dt>
-<dd><ul><li>schema property: card.json#/properties/email/properties/type</li><li>schema property: card.json#/properties/tel/properties/type</li></ul></dd>
-<dt id="term-tz"><code>tz</code></dt>
-<dd><ul><li>schema property: card.json#/properties/tz</li></ul></dd>
-<dt id="term-updated"><code>updated</code></dt>
-<dd><ul><li>schema property: ticket.json#/properties/updated</li></ul></dd>
-<dt id="term-url"><code>url</code></dt>
-<dd><ul><li>schema property: calendar.json#/properties/url</li><li>schema property: card.json#/properties/url</li></ul></dd>
-<dt id="term-value"><code>value</code></dt>
-<dd><ul><li>schema property: card.json#/properties/email/properties/value</li><li>schema property: card.json#/properties/tel/properties/value</li></ul></dd>
-<dt id="term-vegetables"><code>vegetables</code></dt>
-<dd><ul><li>schema property: array.json#/properties/vegetables</li></ul></dd>
-<dt id="term-veggieLike"><code>veggieLike</code></dt>
-<dd><ul><li>schema property: array.json#/definitions/veggie/properties/veggieLike</li></ul></dd>
-<dt id="term-veggieName"><code>veggieName</code></dt>
-<dd><ul><li>schema property: array.json#/definitions/veggie/properties/veggieName</li></ul></dd>
+<dt id="term-additionalName" class="term"><code>additionalName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/additionalName</li></ul></dd>
+<dt id="term-age" class="term alpsBacked" data-alps="age"><code>age</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>
+<dd><p class="borrowedDescriptor">title: Age in years which must be equal to or greater than zero.</p><ul><li class="usage parameterUsage">parameter: GET /alps-fallback {age}</li><li class="usage parameterUsage">parameter: POST /contact {age}</li><li class="usage parameterUsage">parameter: POST /contact-with-descriptions {age}</li><li class="usage parameterUsage">parameter: POST /person {age}</li><li class="usage parameterUsage">parameter: PATCH /person {age}</li><li class="usage parameterUsage">parameter: POST /users/{id} {age}</li><li class="usage parameterUsage">parameter: PUT /users/{id} {age}</li><li class="usage schemaPropertyUsage">schema property: contact.param.json#/properties/age</li><li class="usage schemaPropertyUsage">schema property: person.json#/properties/age</li><li class="usage schemaPropertyUsage">schema property: person.param.json#/properties/age</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/age</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/age</li></ul></dd>
+<dt id="term-assignee" class="term"><code>assignee</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /ticket/{id} {assignee}</li><li class="usage parameterUsage">parameter: PUT /ticket/{id} {assignee}</li><li class="usage parameterUsage">parameter: PUT /ticket/assign {assignee}</li><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/assignee</li><li class="usage schemaPropertyUsage">schema property: ticket.param.json#/properties/assignee</li></ul></dd>
+<dt id="term-bday" class="term"><code>bday</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/bday</li></ul></dd>
+<dt id="term-bothSummaryAndDescription" class="term"><code>bothSummaryAndDescription</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /docblock-variants {bothSummaryAndDescription}</li></ul></dd>
+<dt id="term-builtinType" class="term"><code>builtinType</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /input-edge-cases {builtinType}</li></ul></dd>
+<dt id="term-category" class="term"><code>category</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/category</li></ul></dd>
+<dt id="term-count" class="term"><code>count</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: GET /numbers {count}</li></ul></dd>
+<dt id="term-country-name" class="term"><code>country-name</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/country-name</li></ul></dd>
+<dt id="term-created" class="term"><code>created</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/created</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/created</li></ul></dd>
+<dt id="term-date" class="term"><code>date</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: GET /calendar/{year}/{month} {date}</li></ul></dd>
+<dt id="term-description" class="term"><code>description</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /ticket/{id} {description}</li><li class="usage parameterUsage">parameter: PUT /ticket/{id} {description}</li><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/description</li><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/description</li><li class="usage schemaPropertyUsage">schema property: ticket.param.json#/properties/description</li></ul></dd>
+<dt id="term-docOnly" class="term"><code>docOnly</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: json-schema-input.param.json#/properties/docOnly</li></ul></dd>
+<dt id="term-dtend" class="term"><code>dtend</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/dtend</li></ul></dd>
+<dt id="term-dtstart" class="term"><code>dtstart</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/dtstart</li></ul></dd>
+<dt id="term-duration" class="term"><code>duration</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/duration</li></ul></dd>
+<dt id="term-email" class="term"><code>email</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /contact {email}</li><li class="usage parameterUsage">parameter: POST /contact-with-descriptions {email}</li><li class="usage parameterUsage">parameter: POST /users/{id} {email}</li><li class="usage parameterUsage">parameter: PUT /users/{id} {email}</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/email</li><li class="usage schemaPropertyUsage">schema property: contact.param.json#/properties/email</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/email</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/email</li></ul></dd>
+<dt id="term-enabled" class="term"><code>enabled</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: PUT /users/{id} {enabled}</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/enabled</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/enabled</li></ul></dd>
+<dt id="term-extended-address" class="term"><code>extended-address</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/extended-address</li></ul></dd>
+<dt id="term-familyName" class="term alpsBacked" data-alps="familyName"><code>familyName</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>
+<dd><p class="borrowedDescriptor">def: <a href="https://schema.org/familyName">https://schema.org/familyName</a></p><ul><li class="usage parameterUsage">parameter: GET /alps-fallback {familyName}</li><li class="usage parameterUsage">parameter: POST /person {familyName}</li><li class="usage parameterUsage">parameter: PATCH /person {familyName}</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/familyName</li><li class="usage schemaPropertyUsage">schema property: person.json#/properties/familyName</li><li class="usage schemaPropertyUsage">schema property: person.param.json#/properties/familyName</li></ul></dd>
+<dt id="term-firstName" class="term alpsBacked" data-alps="firstName"><code>firstName</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>
+<dd><p class="borrowedDescriptor">title: First Name by ALPS</p><ul><li class="usage parameterUsage">parameter: GET /alps-fallback {firstName}</li><li class="usage parameterUsage">parameter: POST /person {firstName}</li><li class="usage parameterUsage">parameter: PATCH /person {firstName}</li><li class="usage schemaPropertyUsage">schema property: person.json#/properties/firstName</li><li class="usage schemaPropertyUsage">schema property: person.param.json#/properties/firstName</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/firstName</li></ul></dd>
+<dt id="term-fn" class="term"><code>fn</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/fn</li></ul></dd>
+<dt id="term-foo" class="term"><code>foo</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: GET /alps-fallback {foo}</li></ul></dd>
+<dt id="term-fruits" class="term"><code>fruits</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/properties/fruits</li></ul></dd>
+<dt id="term-givenName" class="term"><code>givenName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/givenName</li></ul></dd>
+<dt id="term-honorificPrefix" class="term"><code>honorificPrefix</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/honorificPrefix</li></ul></dd>
+<dt id="term-honorificSuffix" class="term"><code>honorificSuffix</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/honorificSuffix</li></ul></dd>
+<dt id="term-href" class="term"><code>href</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/_links/properties/self/properties/href</li></ul></dd>
+<dt id="term-id" class="term alpsBacked" data-alps="id"><code>id</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>
+<dd><p class="borrowedDescriptor">title: Person identifier</p><ul><li class="usage parameterUsage">parameter: GET /address {id}</li><li class="usage parameterUsage">parameter: GET /card {id}</li><li class="usage parameterUsage">parameter: GET /org {id}</li><li class="usage parameterUsage">parameter: GET /person {id}</li><li class="usage parameterUsage">parameter: PATCH /person {id}</li><li class="usage parameterUsage">parameter: GET /ticket/{id} {id}</li><li class="usage parameterUsage">parameter: PUT /ticket/{id} {id}</li><li class="usage parameterUsage">parameter: DELETE /ticket/{id} {id}</li><li class="usage parameterUsage">parameter: PUT /ticket/assign {id}</li><li class="usage parameterUsage">parameter: GET /union-type {id}</li><li class="usage parameterUsage">parameter: GET /users/{id} {id}</li><li class="usage parameterUsage">parameter: PUT /users/{id} {id}</li><li class="usage parameterUsage">parameter: DELETE /users/{id} {id}</li><li class="usage schemaPropertyUsage">schema property: org.json#/properties/id</li><li class="usage schemaPropertyUsage">schema property: person.param.json#/properties/id</li><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/id</li><li class="usage schemaPropertyUsage">schema property: ticket.param.json#/properties/id</li><li class="usage schemaPropertyUsage">schema property: user.json#/properties/id</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/id</li></ul></dd>
+<dt id="term-ids" class="term"><code>ids</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: json-schema-input.param.json#/properties/ids</li></ul></dd>
+<dt id="term-items" class="term"><code>items</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: GET /array-data {items}</li></ul></dd>
+<dt id="term-juice" class="term"><code>juice</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/properties/juice</li></ul></dd>
+<dt id="term-juiceLike" class="term"><code>juiceLike</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/definitions/juice/properties/juiceLike</li></ul></dd>
+<dt id="term-juiceName" class="term"><code>juiceName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/definitions/juice/properties/juiceName</li></ul></dd>
+<dt id="term-lastName" class="term"><code>lastName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/lastName</li></ul></dd>
+<dt id="term-locality" class="term"><code>locality</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/locality</li></ul></dd>
+<dt id="term-location" class="term"><code>location</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/location</li></ul></dd>
+<dt id="term-logo" class="term"><code>logo</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/logo</li></ul></dd>
+<dt id="term-modified" class="term"><code>modified</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/modified</li></ul></dd>
+<dt id="term-name" class="term"><code>name</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /contact {name}</li><li class="usage parameterUsage">parameter: POST /contact-with-descriptions {name}</li><li class="usage parameterUsage">parameter: POST /users/{id} {name}</li><li class="usage parameterUsage">parameter: PUT /users/{id} {name}</li><li class="usage schemaPropertyUsage">schema property: contact.param.json#/properties/name</li><li class="usage schemaPropertyUsage">schema property: org.json#/properties/name</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/name</li></ul></dd>
+<dt id="term-nickname" class="term"><code>nickname</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/nickname</li></ul></dd>
+<dt id="term-noCtor" class="term"><code>noCtor</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: PUT /input-edge-cases {noCtor}</li></ul></dd>
+<dt id="term-nonPromoted" class="term"><code>nonPromoted</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /docblock-variants {nonPromoted}</li></ul></dd>
+<dt id="term-options" class="term"><code>options</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: GET /users/{id} {options}</li><li class="usage schemaPropertyUsage">schema property: user.param.json#/properties/options</li></ul></dd>
+<dt id="term-org" class="term"><code>org</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/org</li></ul></dd>
+<dt id="term-organizationName" class="term"><code>organizationName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/org/properties/organizationName</li></ul></dd>
+<dt id="term-organizationUnit" class="term"><code>organizationUnit</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/org/properties/organizationUnit</li></ul></dd>
+<dt id="term-photo" class="term"><code>photo</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/photo</li></ul></dd>
+<dt id="term-post-office-box" class="term"><code>post-office-box</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/post-office-box</li></ul></dd>
+<dt id="term-postal-code" class="term"><code>postal-code</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/postal-code</li></ul></dd>
+<dt id="term-priority" class="term"><code>priority</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/priority</li></ul></dd>
+<dt id="term-rdate" class="term"><code>rdate</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/rdate</li></ul></dd>
+<dt id="term-region" class="term"><code>region</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/region</li></ul></dd>
+<dt id="term-role" class="term"><code>role</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/role</li></ul></dd>
+<dt id="term-rrule" class="term"><code>rrule</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/rrule</li></ul></dd>
+<dt id="term-self" class="term"><code>self</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/_links/properties/self</li></ul></dd>
+<dt id="term-sound" class="term"><code>sound</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/sound</li></ul></dd>
+<dt id="term-status" class="term"><code>status</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: PUT /ticket/{id} {status}</li><li class="usage schemaPropertyUsage">schema property: json-schema-input.param.json#/properties/status</li><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/status</li><li class="usage schemaPropertyUsage">schema property: ticket.param.json#/properties/status</li></ul></dd>
+<dt id="term-street-address" class="term"><code>street-address</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: address.json#/properties/street-address</li></ul></dd>
+<dt id="term-subject" class="term"><code>subject</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /contact {subject}</li><li class="usage parameterUsage">parameter: POST /contact-with-descriptions {subject}</li><li class="usage schemaPropertyUsage">schema property: contact.param.json#/properties/subject</li></ul></dd>
+<dt id="term-summary" class="term"><code>summary</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/summary</li></ul></dd>
+<dt id="term-tagOnly" class="term"><code>tagOnly</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /docblock-variants {tagOnly}</li></ul></dd>
+<dt id="term-tel" class="term"><code>tel</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/tel</li></ul></dd>
+<dt id="term-tickets" class="term"><code>tickets</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/_embedded/properties/tickets</li></ul></dd>
+<dt id="term-title" class="term"><code>title</code></dt>
+<dd><ul><li class="usage parameterUsage">parameter: POST /ticket/{id} {title}</li><li class="usage parameterUsage">parameter: PUT /ticket/{id} {title}</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/title</li><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/title</li><li class="usage schemaPropertyUsage">schema property: ticket.param.json#/properties/title</li></ul></dd>
+<dt id="term-type" class="term"><code>type</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/email/properties/type</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/tel/properties/type</li></ul></dd>
+<dt id="term-tz" class="term"><code>tz</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/tz</li></ul></dd>
+<dt id="term-updated" class="term"><code>updated</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: ticket.json#/properties/updated</li></ul></dd>
+<dt id="term-url" class="term"><code>url</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: calendar.json#/properties/url</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/url</li></ul></dd>
+<dt id="term-value" class="term"><code>value</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: card.json#/properties/email/properties/value</li><li class="usage schemaPropertyUsage">schema property: card.json#/properties/tel/properties/value</li></ul></dd>
+<dt id="term-vegetables" class="term"><code>vegetables</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/properties/vegetables</li></ul></dd>
+<dt id="term-veggieLike" class="term"><code>veggieLike</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/definitions/veggie/properties/veggieLike</li></ul></dd>
+<dt id="term-veggieName" class="term"><code>veggieName</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: array.json#/definitions/veggie/properties/veggieName</li></ul></dd>
 </dl>
 <h2>Reserved Representation Fields</h2>
 <p>Leading-underscore fields are listed separately because they usually belong to the representation format rather than the API domain vocabulary.</p>
 <dl>
-<dt id="field-_embedded"><code>_embedded</code></dt>
-<dd><ul><li>schema property: user.json#/properties/_embedded</li></ul></dd>
-<dt id="field-_links"><code>_links</code></dt>
-<dd><ul><li>schema property: user.json#/properties/_links</li></ul></dd>
+<dt id="field-_embedded" class="reservedField"><code>_embedded</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/_embedded</li></ul></dd>
+<dt id="field-_links" class="reservedField"><code>_links</code></dt>
+<dd><ul><li class="usage schemaPropertyUsage">schema property: user.json#/properties/_links</li></ul></dd>
 </dl>
 </main>
 </body>

--- a/src/TermUsageHtmlRenderer.php
+++ b/src/TermUsageHtmlRenderer.php
@@ -49,7 +49,7 @@ final readonly class TermUsageHtmlRenderer
 </style>
 </head>
 <body>
-<main>
+<main class="termUsageIndex">
 <p><a href="index.html">API Documentation</a></p>
 <h1>Term Usage Index</h1>
 <p>This index reports lexical identifier matches only; it does not prove semantic equivalence. Its own vocabulary (term, alpsBacked, usage, reservedField, coverage) is defined by the profile linked above. A term whose spelling also exists in the configured application ALPS profile is marked <code>alpsBacked</code>; the matched application descriptor id is carried on the entry's <code>data-alps</code> attribute.</p>

--- a/src/TermUsageHtmlRenderer.php
+++ b/src/TermUsageHtmlRenderer.php
@@ -43,7 +43,7 @@ final readonly class TermUsageHtmlRenderer
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Term Usage Index</title>
-<link rel="profile" href="https://bearsunday.github.io/BEAR.ApiDoc/alps/apidoc.xml">
+<link rel="profile" href="https://bearsunday.github.io/BEAR.ApiDoc/alps/terms.xml">
 <style>
 {$styles}
 </style>
@@ -52,14 +52,14 @@ final readonly class TermUsageHtmlRenderer
 <main>
 <p><a href="index.html">API Documentation</a></p>
 <h1>Term Usage Index</h1>
-<p>This index reports lexical identifier matches only; it does not prove semantic equivalence. A term backed by an ALPS descriptor carries that descriptor as its class, per the profile linked above.</p>
+<p>This index reports lexical identifier matches only; it does not prove semantic equivalence. Its own vocabulary (term, alpsBacked, usage, reservedField, coverage) is defined by the profile linked above. A term whose spelling also exists in the configured application ALPS profile is marked <code>alpsBacked</code>; the matched application descriptor id is carried on the entry's <code>data-alps</code> attribute.</p>
 
 <h2>Summary</h2>
 <ul>
-  <li>Terms used in API: {$this->html((string) \count($apiUsages))}</li>
-  <li>Terms with same-name ALPS descriptor: {$this->html((string) $matchedAlpsDescriptorCount)}</li>
-  <li>Lexical ALPS coverage: {$this->html($coverage)}%</li>
-  <li>Reserved representation fields: {$this->html((string) \count($reservedUsages))}</li>
+  <li class="termsUsedCount">Terms used in API: {$this->html((string) \count($apiUsages))}</li>
+  <li class="alpsMatchedCount">Terms with same-name ALPS descriptor: {$this->html((string) $matchedAlpsDescriptorCount)}</li>
+  <li class="lexicalCoverage">Lexical ALPS coverage: {$this->html($coverage)}%</li>
+  <li class="reservedCount">Reserved representation fields: {$this->html((string) \count($reservedUsages))}</li>
 </ul>
 
 {$indexHtml}
@@ -111,7 +111,7 @@ dt code {
     font-size: 1.2em;
     font-weight: 600;
 }
-.alps {
+.mark {
     margin-left: 6px;
     color: #1a7f37;
 }
@@ -214,15 +214,21 @@ CSS;
      */
     private function renderEntry(string $idPrefix, string $term, array $usages, ?array $descriptor): string
     {
-        // The term name stays plain for a consistent column; the ALPS binding is
-        // shown by a checkmark and (machine-readably) by the descriptor-id class.
-        $mark = $descriptor !== null ? '<span class="alps" title="defined in ALPS">&#x2611;</span>' : '';
-        $classAttr = $descriptor !== null ? sprintf(' class="%s"', $this->html($term)) : '';
+        $backed = $descriptor !== null;
+        // Each entry binds to this index's own profile (terms.xml): `term` (or
+        // `term alpsBacked`) for API terms, `reservedField` for representation
+        // fields. The matched application descriptor id is a cross-reference, so
+        // it rides on data-alps rather than masquerading as a profile class.
+        $baseClass = $idPrefix === 'field' ? 'reservedField' : 'term';
+        $class = $backed ? $baseClass . ' alpsBacked' : $baseClass;
+        $dataAlps = $backed ? sprintf(' data-alps="%s"', $this->html($term)) : '';
+        $mark = $backed ? '<span class="mark" title="same-name ALPS descriptor">&#x2611;</span>' : '';
 
         return sprintf(
-            '<dt id="%s"%s><code>%s</code>%s</dt>%s<dd>%s%s</dd>',
+            '<dt id="%s" class="%s"%s><code>%s</code>%s</dt>%s<dd>%s%s</dd>',
             $this->htmlId($idPrefix, $term),
-            $classAttr,
+            $class,
+            $dataAlps,
             $this->html($term),
             $mark,
             PHP_EOL,
@@ -245,7 +251,7 @@ CSS;
                 continue;
             }
 
-            $lines[] = sprintf('<p>%s: %s</p>', $field, $this->renderDescriptorValue($field, $value));
+            $lines[] = sprintf('<p class="borrowedDescriptor">%s: %s</p>', $field, $this->renderDescriptorValue($field, $value));
         }
 
         return implode('', $lines);
@@ -266,10 +272,23 @@ CSS;
     {
         $items = [];
         foreach (array_keys($usages) as $usage) {
-            $items[] = sprintf('<li>%s</li>', $this->html($usage));
+            $items[] = sprintf('<li class="%s">%s</li>', $this->usageClass($usage), $this->html($usage));
         }
 
         return sprintf('<ul>%s</ul>', implode('', $items));
+    }
+
+    private function usageClass(string $usage): string
+    {
+        if (str_starts_with($usage, 'parameter:')) {
+            return 'usage parameterUsage';
+        }
+
+        if (str_starts_with($usage, 'schema property:')) {
+            return 'usage schemaPropertyUsage';
+        }
+
+        return 'usage';
     }
 
     private function htmlId(string $prefix, string $value): string

--- a/tests/TermUsageHtmlRendererTest.php
+++ b/tests/TermUsageHtmlRendererTest.php
@@ -16,7 +16,7 @@ final class TermUsageHtmlRendererTest extends TestCase
         $this->assertStringNotContainsString('Reserved Representation Fields', $html);
     }
 
-    public function testDescriptorBackedTermIsMarkedAndCarriesItsDescriptorAsClass(): void
+    public function testDescriptorBackedTermIsMarkedAndBoundToAlpsBackedDescriptor(): void
     {
         $html = (new TermUsageHtmlRenderer())->render(
             ['emptyDescriptor' => ['parameter: GET /empty {emptyDescriptor}' => true]],
@@ -26,9 +26,10 @@ final class TermUsageHtmlRendererTest extends TestCase
             '100',
         );
 
-        // ALPS-defined terms get a checkmark plus the descriptor id as class.
-        $this->assertStringContainsString('class="emptyDescriptor"', $html);
-        $this->assertStringContainsString('<span class="alps" title="defined in ALPS">&#x2611;</span>', $html);
+        // ALPS-backed terms bind to the index profile via `term alpsBacked`, cross-reference
+        // the application descriptor through data-alps, and show a checkmark.
+        $this->assertStringContainsString('class="term alpsBacked" data-alps="emptyDescriptor"', $html);
+        $this->assertStringContainsString('<span class="mark" title="same-name ALPS descriptor">&#x2611;</span>', $html);
         // An empty descriptor contributes no attribute lines, so the dd opens straight into usages.
         $this->assertStringContainsString('<dd><ul>', $html);
     }
@@ -50,10 +51,10 @@ final class TermUsageHtmlRendererTest extends TestCase
         );
 
         // The term name stays plain; only the def value is a link.
-        $this->assertStringContainsString('<dt id="term-familyName" class="familyName"><code>familyName</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>', $html);
-        $this->assertStringContainsString('<p>def: <a href="https://schema.org/familyName">https://schema.org/familyName</a></p>', $html);
+        $this->assertStringContainsString('<dt id="term-familyName" class="term alpsBacked" data-alps="familyName"><code>familyName</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>', $html);
+        $this->assertStringContainsString('<p class="borrowedDescriptor">def: <a href="https://schema.org/familyName">https://schema.org/familyName</a></p>', $html);
         // A non-URL def is shown as a labelled attribute, in field order (title, def, doc).
-        $this->assertStringContainsString('<p>def: identifier</p><p>doc: A role within the org</p>', $html);
+        $this->assertStringContainsString('<p class="borrowedDescriptor">def: identifier</p><p class="borrowedDescriptor">doc: A role within the org</p>', $html);
     }
 
     /**

--- a/tests/TermUsageHtmlRendererTest.php
+++ b/tests/TermUsageHtmlRendererTest.php
@@ -57,6 +57,24 @@ final class TermUsageHtmlRendererTest extends TestCase
         $this->assertStringContainsString('<p class="borrowedDescriptor">def: identifier</p><p class="borrowedDescriptor">doc: A role within the org</p>', $html);
     }
 
+    public function testUsageWithoutKnownPrefixFallsBackToTheBareUsageClass(): void
+    {
+        // render() is public and accepts arbitrary usage strings. Production strings
+        // always start with "parameter:" or "schema property:", but a string that
+        // matches neither must still bind to the generic `usage` descriptor.
+        $html = (new TermUsageHtmlRenderer())->render(
+            ['orphan' => ['header: X-Orphan' => true]],
+            [],
+            [],
+            0,
+            '0',
+        );
+
+        $this->assertStringContainsString('<li class="usage">header: X-Orphan</li>', $html);
+        $this->assertStringNotContainsString('parameterUsage', $html);
+        $this->assertStringNotContainsString('schemaPropertyUsage', $html);
+    }
+
     /**
      * Parameter-derived terms are always valid PHP identifiers, so symbols never
      * arise from method signatures. However, JSON Schemas are reusable, independent

--- a/tests/TermUsageIndexTest.php
+++ b/tests/TermUsageIndexTest.php
@@ -74,6 +74,8 @@ final class TermUsageIndexTest extends TestCase
         $html = (new TermUsageIndex($config))->generateHtml();
 
         $this->assertStringContainsString('<title>Term Usage Index</title>', $html);
+        // The document as a whole binds to the termUsageIndex descriptor.
+        $this->assertStringContainsString('<main class="termUsageIndex">', $html);
         $this->assertStringContainsString('<a href="index.html">API Documentation</a>', $html);
         $this->assertStringContainsString('<li class="termsUsedCount">Terms used in API:', $html);
         // The Index links each term (and reserved field) down to its entry anchor.

--- a/tests/TermUsageIndexTest.php
+++ b/tests/TermUsageIndexTest.php
@@ -75,14 +75,14 @@ final class TermUsageIndexTest extends TestCase
 
         $this->assertStringContainsString('<title>Term Usage Index</title>', $html);
         $this->assertStringContainsString('<a href="index.html">API Documentation</a>', $html);
-        $this->assertStringContainsString('<li>Terms used in API:', $html);
+        $this->assertStringContainsString('<li class="termsUsedCount">Terms used in API:', $html);
         // The Index links each term (and reserved field) down to its entry anchor.
         $this->assertStringContainsString('<ul class="index-list">', $html);
         $this->assertStringContainsString('<li><a href="#term-firstName">firstName</a></li>', $html);
         $this->assertStringContainsString('<li><a href="#field-_links">_links</a></li>', $html);
-        $this->assertStringContainsString('<dt id="term-firstName" class="firstName"><code>firstName</code><span class="alps" title="defined in ALPS">&#x2611;</span></dt>', $html);
-        $this->assertStringContainsString('<dd><p>title: firstName by ALPS</p>', $html);
-        $this->assertStringContainsString('<li>parameter: POST /person {firstName}</li>', $html);
+        $this->assertStringContainsString('<dt id="term-firstName" class="term alpsBacked" data-alps="firstName"><code>firstName</code><span class="mark" title="same-name ALPS descriptor">&#x2611;</span></dt>', $html);
+        $this->assertStringContainsString('<dd><p class="borrowedDescriptor">title: firstName by ALPS</p>', $html);
+        $this->assertStringContainsString('<li class="usage parameterUsage">parameter: POST /person {firstName}</li>', $html);
         $this->assertStringContainsString('<h2>Reserved Representation Fields</h2>', $html);
     }
 


### PR DESCRIPTION
## Problem

`terms.html` (Term Usage Index) is a meta-document: it lists the identifiers used across the generated API documentation and records where each one appears. But it declared `rel="profile"` pointing at `apidoc.xml`, which describes the **main API documentation's** vocabulary (`endpoint`/`param`/`object`), not this index's own vocabulary.

It also stamped ALPS-backed terms with `class="<term>"` (e.g. `class="age"`). That class only makes sense against the configured **application** ALPS profile (which defines `age`, `familyName`, …), not against the declared `apidoc.xml`. Declared profile and class target disagreed, so no element on the page could actually be machine-bound to the profile it claimed to conform to.

## Change

- Add `docs/alps/terms.xml` — a profile describing the index's **own** vocabulary: `term`, `alpsBacked`, `borrowedDescriptor`, `usage` (refined to `parameterUsage` / `schemaPropertyUsage`), `reservedField`, and the summary figures (`termsUsedCount`, `alpsMatchedCount`, `lexicalCoverage`, `reservedCount`).
- Point `terms.html` at the new profile and bind every semantic element to a descriptor by `class`.
- ALPS-backed entries now carry `class="term alpsBacked"` and cross-reference the application descriptor through a `data-alps` attribute, instead of impersonating a profile class.
- Reword the misleading intro paragraph and rename the checkmark CSS class accordingly.

After this change, every semantic class on the page binds to a descriptor in the declared profile; the only unbound classes are the purely presentational `mark` (checkmark) and `index-list`.

## Tests

- [x] `composer cs-fix`
- [x] `composer sa` (PHPStan + Psalm)
- [x] `composer test` (120 tests, 506 assertions)