### PR TITLE
Remove PHP app-state-diagram dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "ray/di": "^2.16",
         "rize/uri-template": "^0.3.3 || ^0.4",
         "bear/package": "^1.9",
-        "koriym/app-state-diagram": "^0.11 ",
         "michelf/php-markdown": "^1.9.1 || ^2.0",
         "koriym/psr4list": "^1.0.1",
         "ray/aop": "^2.10",
@@ -37,7 +36,8 @@
     },
     "autoload": {
         "psr-4": {
-            "BEAR\\ApiDoc\\": "src/"
+            "BEAR\\ApiDoc\\": "src/",
+            "AlpsAsd\\AlpsProfile\\": "src-alps/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
         "sa": [
             "./vendor/bin/phpstan analyse -c phpstan.neon --memory-limit=1G",
             "./vendor/bin/psalm --show-info=true",
-            "php -d error_reporting=24575 ./vendor/bin/phpmd src text phpmd.xml"
+            "php -d error_reporting=24575 ./vendor/bin/phpmd src,src-alps text phpmd.xml"
         ],
         "tests": [
             "@cs",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -17,6 +17,7 @@
 
     <!-- Directories to be checked -->
     <file>src</file>
+    <file>src-alps</file>
     <file>tests</file>
     <exclude-pattern>*/tmp/*</exclude-pattern>
     <exclude-pattern>*/Fake/*</exclude-pattern>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,6 +2,7 @@ parameters:
   level: max
   paths:
     - src
+    - src-alps
     - tests
 
   excludePaths:

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,6 +11,7 @@
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="src-alps" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>

--- a/src-alps/Exception/InvalidProfileException.php
+++ b/src-alps/Exception/InvalidProfileException.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlpsAsd\AlpsProfile\Exception;
+
+use RuntimeException;
+
+/**
+ * Thrown when an ALPS profile cannot be read or parsed.
+ *
+ * A broken profile must fail loudly rather than silently producing
+ * documentation with missing semantic text.
+ */
+final class InvalidProfileException extends RuntimeException
+{
+}

--- a/src-alps/ProfileDictionary.php
+++ b/src-alps/ProfileDictionary.php
@@ -4,18 +4,29 @@ declare(strict_types=1);
 
 namespace AlpsAsd\AlpsProfile;
 
+use AlpsAsd\AlpsProfile\Exception\InvalidProfileException;
 use ArrayObject;
 use JsonException;
 use SimpleXMLElement;
 
+use function array_key_exists;
+use function array_values;
+use function dirname;
 use function file_get_contents;
 use function is_array;
 use function is_string;
 use function json_decode;
 use function pathinfo;
+use function realpath;
+use function simplexml_load_file;
 use function sprintf;
+use function str_starts_with;
+use function strpos;
+use function substr;
+use function strtolower;
 use function trim;
 
+use const DIRECTORY_SEPARATOR;
 use const JSON_THROW_ON_ERROR;
 use const PATHINFO_EXTENSION;
 
@@ -24,6 +35,11 @@ use const PATHINFO_EXTENSION;
  *
  * This intentionally contains only the small profile-reading surface needed by
  * BEAR.ApiDoc. Diagram rendering belongs to the JavaScript ASD package.
+ *
+ * External descriptor references (`{"href": "common.json#id"}`) are resolved by
+ * loading the referenced file so that profiles split across files keep their
+ * labels. Invalid or unreadable profiles fail loudly with
+ * {@see InvalidProfileException}.
  */
 final readonly class ProfileDictionary
 {
@@ -35,46 +51,23 @@ final readonly class ProfileDictionary
 
     public static function fromFile(string $file): self
     {
-        return match (pathinfo($file, PATHINFO_EXTENSION)) {
-            'json' => self::fromJsonFile($file),
-            default => self::fromXmlFile($file),
-        };
+        $cache = [];
+
+        return new self(self::dictForFile($file, $cache));
     }
 
     public static function fromJsonFile(string $file): self
     {
-        $contents = file_get_contents($file);
-        if ($contents === false) {
-            return new self([]);
-        }
+        $cache = [];
 
-        try {
-            $profile = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException) {
-            return new self([]);
-        }
-
-        if (! is_array($profile)) {
-            return new self([]);
-        }
-
-        $dictionary = [];
-        self::collectJsonDescriptors($profile, $dictionary);
-
-        return new self($dictionary);
+        return new self(self::dictForParsedFile($file, 'json', $cache));
     }
 
     public static function fromXmlFile(string $file): self
     {
-        $xml = @simplexml_load_file($file);
-        if (! $xml instanceof SimpleXMLElement) {
-            return new self([]);
-        }
+        $cache = [];
 
-        $dictionary = [];
-        self::collectXmlDescriptors($xml, $dictionary);
-
-        return new self($dictionary);
+        return new self(self::dictForParsedFile($file, 'xml', $cache));
     }
 
     /**
@@ -97,27 +90,119 @@ final readonly class ProfileDictionary
     }
 
     /**
-     * @param array<array-key, mixed> $node
-     * @param array<string, string>   $dictionary
+     * @param array<string, array<string, string>|null> $cache
+     *
+     * @return array<string, string>
      */
-    private static function collectJsonDescriptors(array $node, array &$dictionary): void
+    private static function dictForFile(string $file, array &$cache): array
     {
-        if (isset($node['id']) && is_string($node['id'])) {
-            $dictionary[$node['id']] = self::titleFromJsonDescriptor($node);
-        }
+        $format = strtolower(pathinfo($file, PATHINFO_EXTENSION)) === 'xml' ? 'xml' : 'json';
 
-        foreach ($node as $value) {
-            if (! is_array($value)) {
-                continue;
-            }
-
-            self::collectJsonDescriptors($value, $dictionary);
-        }
+        return self::dictForParsedFile($file, $format, $cache);
     }
 
     /**
-     * @param array<array-key, mixed> $node
+     * @param array<string, array<string, string>|null> $cache realpath => dictionary (null while being built, as a loop guard)
+     *
+     * @return array<string, string>
      */
+    private static function dictForParsedFile(string $file, string $format, array &$cache): array
+    {
+        $key = self::cacheKey($file);
+        if (array_key_exists($key, $cache)) {
+            return $cache[$key] ?? [];
+        }
+
+        $cache[$key] = null;
+        $dictionary = $format === 'json'
+            ? self::collectJson($file, $cache)
+            : self::collectXml($file, $cache);
+        $cache[$key] = $dictionary;
+
+        return $dictionary;
+    }
+
+    /**
+     * @param array<string, array<string, string>|null> $cache
+     *
+     * @return array<string, string>
+     */
+    private static function collectJson(string $file, array &$cache): array
+    {
+        $contents = @file_get_contents($file);
+        if ($contents === false) {
+            throw new InvalidProfileException(sprintf('Cannot read ALPS profile: %s', $file));
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            throw new InvalidProfileException(sprintf('Invalid JSON ALPS profile: %s', $file), 0, $e);
+        }
+
+        if (! is_array($decoded)) {
+            throw new InvalidProfileException(sprintf('Invalid ALPS profile: %s', $file));
+        }
+
+        $dictionary = [];
+        self::walkJsonDescriptors(self::jsonDescriptorList($decoded), dirname($file), $dictionary, $cache);
+
+        return $dictionary;
+    }
+
+    /**
+     * @param array<array-key, mixed> $decoded
+     *
+     * @return array<array-key, mixed>
+     */
+    private static function jsonDescriptorList(array $decoded): array
+    {
+        /** @var mixed $alps */
+        $alps = $decoded['alps'] ?? null;
+        if (is_array($alps) && isset($alps['descriptor']) && is_array($alps['descriptor'])) {
+            return array_values($alps['descriptor']);
+        }
+
+        if (isset($decoded['descriptor']) && is_array($decoded['descriptor'])) {
+            return array_values($decoded['descriptor']);
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<array-key, mixed>                    $descriptors
+     * @param array<string, string>                      $dictionary
+     * @param array<string, array<string, string>|null>  $cache
+     */
+    private static function walkJsonDescriptors(array $descriptors, string $baseDir, array &$dictionary, array &$cache): void
+    {
+        foreach ($descriptors as $descriptor) {
+            if (! is_array($descriptor)) {
+                continue;
+            }
+
+            if (isset($descriptor['id']) && is_string($descriptor['id'])) {
+                $dictionary[$descriptor['id']] = self::titleFromJsonDescriptor($descriptor);
+                self::resolveTarget($descriptor['rt'] ?? null, $baseDir, $dictionary, $cache);
+
+                /** @var mixed $nested */
+                $nested = $descriptor['descriptor'] ?? null;
+                if (is_array($nested)) {
+                    self::walkJsonDescriptors(array_values($nested), $baseDir, $dictionary, $cache);
+                }
+
+                continue;
+            }
+
+            if (isset($descriptor['href']) && is_string($descriptor['href'])) {
+                self::resolveHref($descriptor['href'], $baseDir, $dictionary, $cache);
+            }
+        }
+    }
+
+    /** @param array<array-key, mixed> $node */
     private static function titleFromJsonDescriptor(array $node): string
     {
         if (isset($node['title']) && is_string($node['title']) && $node['title'] !== '') {
@@ -129,8 +214,10 @@ final readonly class ProfileDictionary
             return $doc;
         }
 
-        if (isset($node['def']) && is_string($node['def']) && $node['def'] !== '') {
-            return sprintf('[%s](%s)', $node['def'], $node['def']);
+        foreach (['def', 'ref', 'src'] as $key) {
+            if (isset($node[$key]) && is_string($node[$key]) && $node[$key] !== '') {
+                return sprintf('[%s](%s)', $node[$key], $node[$key]);
+            }
         }
 
         return '';
@@ -149,21 +236,49 @@ final readonly class ProfileDictionary
         return '';
     }
 
-    /** @param array<string, string> $dictionary */
-    private static function collectXmlDescriptors(SimpleXMLElement $node, array &$dictionary): void
+    /**
+     * @param array<string, array<string, string>|null> $cache
+     *
+     * @return array<string, string>
+     */
+    private static function collectXml(string $file, array &$cache): array
     {
-        $id = (string) $node['id'];
-        if ($id !== '') {
-            $dictionary[$id] = self::titleFromXmlDescriptor($node);
+        $xml = @simplexml_load_file($file);
+        if (! $xml instanceof SimpleXMLElement) {
+            throw new InvalidProfileException(sprintf('Invalid XML ALPS profile: %s', $file));
         }
 
+        $dictionary = [];
+        self::walkXmlDescriptors($xml, dirname($file), $dictionary, $cache);
+
+        return $dictionary;
+    }
+
+    /**
+     * @param array<string, string>                     $dictionary
+     * @param array<string, array<string, string>|null> $cache
+     */
+    private static function walkXmlDescriptors(SimpleXMLElement $node, string $baseDir, array &$dictionary, array &$cache): void
+    {
         foreach ($node->children() ?? [] as $child) {
             /** @var SimpleXMLElement $child */
             if ($child->getName() !== 'descriptor') {
                 continue;
             }
 
-            self::collectXmlDescriptors($child, $dictionary);
+            $id = (string) $child['id'];
+            if ($id !== '') {
+                $dictionary[$id] = self::titleFromXmlDescriptor($child);
+                self::resolveTarget((string) $child['rt'], $baseDir, $dictionary, $cache);
+                self::walkXmlDescriptors($child, $baseDir, $dictionary, $cache);
+
+                continue;
+            }
+
+            $href = (string) $child['href'];
+            if ($href !== '') {
+                self::resolveHref($href, $baseDir, $dictionary, $cache);
+            }
         }
     }
 
@@ -175,6 +290,7 @@ final readonly class ProfileDictionary
         }
 
         foreach ($node->children() ?? [] as $child) {
+            /** @var SimpleXMLElement $child */
             if ($child->getName() !== 'doc') {
                 continue;
             }
@@ -190,11 +306,74 @@ final readonly class ProfileDictionary
             }
         }
 
-        $def = (string) $node['def'];
-        if ($def !== '') {
-            return sprintf('[%s](%s)', $def, $def);
+        foreach (['def', 'ref', 'src'] as $attribute) {
+            $value = (string) $node[$attribute];
+            if ($value !== '') {
+                return sprintf('[%s](%s)', $value, $value);
+            }
         }
 
         return '';
+    }
+
+    /**
+     * Resolve an external descriptor reference (`file#id`) into the dictionary.
+     *
+     * Internal references (`#id`) are ignored because the target descriptor is
+     * collected from its inline definition in the same file.
+     *
+     * @param array<string, string>                     $dictionary
+     * @param array<string, array<string, string>|null> $cache
+     */
+    private static function resolveHref(string $href, string $baseDir, array &$dictionary, array &$cache): void
+    {
+        self::resolveTarget($href, $baseDir, $dictionary, $cache);
+    }
+
+    /**
+     * @param array<string, string>                     $dictionary
+     * @param array<string, array<string, string>|null> $cache
+     */
+    private static function resolveTarget(mixed $target, string $baseDir, array &$dictionary, array &$cache): void
+    {
+        if (! is_string($target) || $target === '') {
+            return;
+        }
+
+        $hashPosition = strpos($target, '#');
+        if ($hashPosition === false) {
+            return;
+        }
+
+        $filePart = substr($target, 0, $hashPosition);
+        $id = substr($target, $hashPosition + 1);
+        if ($filePart === '' || $id === '') {
+            return;
+        }
+
+        $external = self::dictForFile(self::resolvePath($filePart, $baseDir), $cache);
+        if (isset($external[$id]) && ! isset($dictionary[$id])) {
+            $dictionary[$id] = $external[$id];
+        }
+    }
+
+    private static function resolvePath(string $filePart, string $baseDir): string
+    {
+        if (str_starts_with($filePart, 'http://') || str_starts_with($filePart, 'https://')) {
+            return $filePart;
+        }
+
+        if ($filePart[0] === '/') {
+            return $filePart;
+        }
+
+        return $baseDir . DIRECTORY_SEPARATOR . $filePart;
+    }
+
+    private static function cacheKey(string $file): string
+    {
+        $real = realpath($file);
+
+        return $real === false ? $file : $real;
     }
 }

--- a/src-alps/ProfileDictionary.php
+++ b/src-alps/ProfileDictionary.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlpsAsd\AlpsProfile;
+
+use ArrayObject;
+use JsonException;
+use SimpleXMLElement;
+
+use function file_get_contents;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function pathinfo;
+use function sprintf;
+use function trim;
+
+use const JSON_THROW_ON_ERROR;
+use const PATHINFO_EXTENSION;
+
+/**
+ * Reads ALPS profile descriptors into an id => title/doc/def dictionary.
+ *
+ * This intentionally contains only the small profile-reading surface needed by
+ * BEAR.ApiDoc. Diagram rendering belongs to the JavaScript ASD package.
+ */
+final readonly class ProfileDictionary
+{
+    /** @param array<string, string> $dictionary */
+    private function __construct(
+        private array $dictionary,
+    ) {
+    }
+
+    public static function fromFile(string $file): self
+    {
+        return match (pathinfo($file, PATHINFO_EXTENSION)) {
+            'json' => self::fromJsonFile($file),
+            default => self::fromXmlFile($file),
+        };
+    }
+
+    public static function fromJsonFile(string $file): self
+    {
+        $contents = file_get_contents($file);
+        if ($contents === false) {
+            return new self([]);
+        }
+
+        try {
+            $profile = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return new self([]);
+        }
+
+        if (! is_array($profile)) {
+            return new self([]);
+        }
+
+        $dictionary = [];
+        self::collectJsonDescriptors($profile, $dictionary);
+
+        return new self($dictionary);
+    }
+
+    public static function fromXmlFile(string $file): self
+    {
+        $xml = @simplexml_load_file($file);
+        if (! $xml instanceof SimpleXMLElement) {
+            return new self([]);
+        }
+
+        $dictionary = [];
+        self::collectXmlDescriptors($xml, $dictionary);
+
+        return new self($dictionary);
+    }
+
+    /**
+     * @return ArrayObject<string, string>
+     *
+     * @psalm-suppress MixedMethodCall ArrayObject is intentionally used by BEAR.ApiDoc's existing API surface.
+     */
+    public function toArrayObject(): ArrayObject
+    {
+        /** @var ArrayObject<string, string> $dictionary */
+        $dictionary = new ArrayObject($this->dictionary);
+
+        return $dictionary;
+    }
+
+    /** @return array<string, string> */
+    public function toArray(): array
+    {
+        return $this->dictionary;
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     * @param array<string, string>   $dictionary
+     */
+    private static function collectJsonDescriptors(array $node, array &$dictionary): void
+    {
+        if (isset($node['id']) && is_string($node['id'])) {
+            $dictionary[$node['id']] = self::titleFromJsonDescriptor($node);
+        }
+
+        foreach ($node as $value) {
+            if (! is_array($value)) {
+                continue;
+            }
+
+            self::collectJsonDescriptors($value, $dictionary);
+        }
+    }
+
+    /**
+     * @param array<array-key, mixed> $node
+     */
+    private static function titleFromJsonDescriptor(array $node): string
+    {
+        if (isset($node['title']) && is_string($node['title']) && $node['title'] !== '') {
+            return $node['title'];
+        }
+
+        $doc = self::docFromJson($node['doc'] ?? null);
+        if ($doc !== '') {
+            return $doc;
+        }
+
+        if (isset($node['def']) && is_string($node['def']) && $node['def'] !== '') {
+            return sprintf('[%s](%s)', $node['def'], $node['def']);
+        }
+
+        return '';
+    }
+
+    private static function docFromJson(mixed $doc): string
+    {
+        if (is_string($doc)) {
+            return trim($doc);
+        }
+
+        if (is_array($doc) && isset($doc['value']) && is_string($doc['value'])) {
+            return trim($doc['value']);
+        }
+
+        return '';
+    }
+
+    /** @param array<string, string> $dictionary */
+    private static function collectXmlDescriptors(SimpleXMLElement $node, array &$dictionary): void
+    {
+        $id = (string) $node['id'];
+        if ($id !== '') {
+            $dictionary[$id] = self::titleFromXmlDescriptor($node);
+        }
+
+        foreach ($node->children() ?? [] as $child) {
+            /** @var SimpleXMLElement $child */
+            if ($child->getName() !== 'descriptor') {
+                continue;
+            }
+
+            self::collectXmlDescriptors($child, $dictionary);
+        }
+    }
+
+    private static function titleFromXmlDescriptor(SimpleXMLElement $node): string
+    {
+        $title = (string) $node['title'];
+        if ($title !== '') {
+            return $title;
+        }
+
+        foreach ($node->children() ?? [] as $child) {
+            if ($child->getName() !== 'doc') {
+                continue;
+            }
+
+            $value = trim((string) $child);
+            if ($value !== '') {
+                return $value;
+            }
+
+            $attributeValue = trim((string) $child['value']);
+            if ($attributeValue !== '') {
+                return $attributeValue;
+            }
+        }
+
+        $def = (string) $node['def'];
+        if ($def !== '') {
+            return sprintf('[%s](%s)', $def, $def);
+        }
+
+        return '';
+    }
+}

--- a/src-alps/ProfileDictionary.php
+++ b/src-alps/ProfileDictionary.php
@@ -20,7 +20,7 @@ use function pathinfo;
 use function realpath;
 use function simplexml_load_file;
 use function sprintf;
-use function str_starts_with;
+use function str_contains;
 use function strpos;
 use function substr;
 use function strtolower;
@@ -36,9 +36,14 @@ use const PATHINFO_EXTENSION;
  * This intentionally contains only the small profile-reading surface needed by
  * BEAR.ApiDoc. Diagram rendering belongs to the JavaScript ASD package.
  *
- * External descriptor references (`{"href": "common.json#id"}`) are resolved by
- * loading the referenced file so that profiles split across files keep their
- * labels. Invalid or unreadable profiles fail loudly with
+ * External descriptor references (`{"href": "common.json#id"}`) and transition
+ * targets (`"rt": "common.json#id"`) are resolved by loading the referenced
+ * file so that profiles split across files keep their labels. Remote references
+ * (`http://`, `https://`) are not fetched; their labels fall back to the
+ * descriptor id. Cross-file references are resolved in a single direction and a
+ * per-file loop guard keeps cyclic references from recursing infinitely: a file
+ * that is still being read contributes no labels back to the file referencing
+ * it. Invalid or unreadable local profiles fail loudly with
  * {@see InvalidProfileException}.
  */
 final readonly class ProfileDictionary
@@ -351,6 +356,12 @@ final readonly class ProfileDictionary
             return;
         }
 
+        // Remote profiles are not fetched: this avoids network access (SSRF) and
+        // offline failures. Such references fall back to the descriptor id.
+        if (str_contains($filePart, '://')) {
+            return;
+        }
+
         $external = self::dictForFile(self::resolvePath($filePart, $baseDir), $cache);
         if (isset($external[$id]) && ! isset($dictionary[$id])) {
             $dictionary[$id] = $external[$id];
@@ -359,10 +370,6 @@ final readonly class ProfileDictionary
 
     private static function resolvePath(string $filePart, string $baseDir): string
     {
-        if (str_starts_with($filePart, 'http://') || str_starts_with($filePart, 'https://')) {
-            return $filePart;
-        }
-
         if ($filePart[0] === '/') {
             return $filePart;
         }

--- a/src/ApiDoc.php
+++ b/src/ApiDoc.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace BEAR\ApiDoc;
 
+use AlpsAsd\AlpsProfile\ProfileDictionary;
 use ArrayObject;
 use BEAR\ApiDoc\Exception\AlpsFileNotFoundException;
 use BEAR\ApiDoc\Exception\NotWritableException;
 use FilesystemIterator;
 use Generator;
-use Koriym\AppStateDiagram\LabelName;
-use Koriym\AppStateDiagram\Profile;
-use Koriym\AppStateDiagram\SemanticDescriptor;
 use RecursiveDirectoryIterator;
 use ReflectionClass;
 use SplFileInfo;
@@ -24,8 +22,6 @@ use function file_exists;
 use function file_put_contents;
 use function implode;
 use function is_dir;
-use function is_object;
-use function is_string;
 use function mkdir;
 use function realpath;
 use function sprintf;
@@ -232,34 +228,7 @@ final readonly class ApiDoc
             throw new AlpsFileNotFoundException($file);
         }
 
-        $alps = new Profile($file, new LabelName());
-        /** @var  ArrayObject<string, string> $semanticDictionary */
-        $semanticDictionary = new ArrayObject();
-        foreach ($alps->descriptors as $descriptor) {
-            if ($descriptor instanceof SemanticDescriptor) {
-                $semanticDictionary[$descriptor->id] = $this->getSemanticTitle($descriptor);
-            }
-        }
-
-        return $semanticDictionary;
-    }
-
-    /** @psalm-external-mutation-free */
-    private function getSemanticTitle(SemanticDescriptor $descriptor): string
-    {
-        if ($descriptor->title !== '' && $descriptor->title !== '0') {
-            return $descriptor->title;
-        }
-
-        if (is_object($descriptor->doc) && isset($descriptor->doc->value) && is_string($descriptor->doc->value)) {
-            return $descriptor->doc->value;
-        }
-
-        if (isset($descriptor->def)) {
-            return sprintf('[%s](%s)', $descriptor->def, $descriptor->def);
-        }
-
-        return '';
+        return ProfileDictionary::fromFile($file)->toArrayObject();
     }
 
     private function copySchema(string $inputDir, string $outputDir): void

--- a/tests/ProfileDictionaryTest.php
+++ b/tests/ProfileDictionaryTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace BEAR\ApiDoc;
 
+use AlpsAsd\AlpsProfile\Exception\InvalidProfileException;
 use AlpsAsd\AlpsProfile\ProfileDictionary;
 use PHPUnit\Framework\TestCase;
 
 use function assert;
+use function basename;
 use function file_put_contents;
+use function sprintf;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
@@ -64,6 +67,8 @@ JSON;
     <doc value="Attribute doc fallback"/>
   </descriptor>
   <descriptor id="defThird" def="https://schema.org/identifier"/>
+  <descriptor id="refFallback" ref="https://schema.org/ref"/>
+  <descriptor id="srcFallback" src="https://schema.org/src"/>
   <descriptor id="empty"/>
   <descriptor id="Parent">
     <descriptor id="nested" title="Nested title"/>
@@ -82,6 +87,8 @@ XML;
         $this->assertSame('Doc fallback', $dictionary['docSecond']);
         $this->assertSame('Attribute doc fallback', $dictionary['docAttribute']);
         $this->assertSame('[https://schema.org/identifier](https://schema.org/identifier)', $dictionary['defThird']);
+        $this->assertSame('[https://schema.org/ref](https://schema.org/ref)', $dictionary['refFallback']);
+        $this->assertSame('[https://schema.org/src](https://schema.org/src)', $dictionary['srcFallback']);
         $this->assertSame('', $dictionary['empty']);
         $this->assertSame('Nested title', $dictionary['nested']);
     }
@@ -97,6 +104,129 @@ XML;
         }
 
         $this->assertSame('First Name', $dictionary['firstName']);
+    }
+
+    public function testJsonRefAndSrcAreUsedAsDefFallback(): void
+    {
+        $profile = <<<'JSON'
+{
+  "alps": {
+    "descriptor": [
+      {"id": "byRef", "ref": "https://schema.org/ref"},
+      {"id": "bySrc", "src": "https://schema.org/src"}
+    ]
+  }
+}
+JSON;
+        $file = $this->writeTempFile($profile, '.json');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArray();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('[https://schema.org/ref](https://schema.org/ref)', $dictionary['byRef']);
+        $this->assertSame('[https://schema.org/src](https://schema.org/src)', $dictionary['bySrc']);
+    }
+
+    public function testResolvesExternalHrefReference(): void
+    {
+        $external = $this->writeTempFile('{"alps":{"descriptor":[{"id":"sharedName","title":"Shared from external"}]}}', '.json');
+        $main = $this->writeTempFile(sprintf('{"alps":{"descriptor":[{"href":"%s#sharedName"}]}}', basename($external)), '.json');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($main)->toArray();
+        } finally {
+            @unlink($main);
+            @unlink($external);
+        }
+
+        $this->assertSame('Shared from external', $dictionary['sharedName']);
+    }
+
+    public function testResolvesExternalRtReference(): void
+    {
+        $external = $this->writeTempFile('{"alps":{"descriptor":[{"id":"SharedState","title":"Shared state"}]}}', '.json');
+        $main = $this->writeTempFile(
+            sprintf('{"alps":{"descriptor":[{"id":"goShared","type":"safe","rt":"%s#SharedState","title":"Go shared"}]}}', basename($external)),
+            '.json',
+        );
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($main)->toArray();
+        } finally {
+            @unlink($main);
+            @unlink($external);
+        }
+
+        $this->assertSame('Go shared', $dictionary['goShared']);
+        $this->assertSame('Shared state', $dictionary['SharedState']);
+    }
+
+    public function testResolvesExternalHrefNestedInsideParentDescriptor(): void
+    {
+        $external = $this->writeTempFile('{"alps":{"descriptor":[{"id":"city","title":"City name"}]}}', '.json');
+        $main = $this->writeTempFile(
+            sprintf('{"alps":{"descriptor":[{"id":"Address","title":"Address","descriptor":[{"href":"%s#city"}]}]}}', basename($external)),
+            '.json',
+        );
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($main)->toArray();
+        } finally {
+            @unlink($main);
+            @unlink($external);
+        }
+
+        $this->assertSame('Address', $dictionary['Address']);
+        $this->assertSame('City name', $dictionary['city']);
+    }
+
+    public function testFromFileTreatsNonXmlExtensionAsJson(): void
+    {
+        $file = $this->writeTempFile('{"alps":{"descriptor":[{"id":"upper","title":"Upper JSON"}]}}', '.JSON');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArray();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('Upper JSON', $dictionary['upper']);
+    }
+
+    public function testInvalidJsonProfileThrows(): void
+    {
+        $file = $this->writeTempFile('{ this is : not json', '.json');
+
+        $this->expectException(InvalidProfileException::class);
+
+        try {
+            ProfileDictionary::fromFile($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testInvalidXmlProfileThrows(): void
+    {
+        $file = $this->writeTempFile('<alps><descriptor', '.xml');
+
+        $this->expectException(InvalidProfileException::class);
+
+        try {
+            ProfileDictionary::fromFile($file);
+        } finally {
+            @unlink($file);
+        }
+    }
+
+    public function testUnreadableProfileThrows(): void
+    {
+        $this->expectException(InvalidProfileException::class);
+
+        ProfileDictionary::fromJsonFile(sys_get_temp_dir() . '/bear-apidoc-missing-profile.json');
     }
 
     private function writeTempFile(string $contents, string $extension): string

--- a/tests/ProfileDictionaryTest.php
+++ b/tests/ProfileDictionaryTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BEAR\ApiDoc;
+
+use AlpsAsd\AlpsProfile\ProfileDictionary;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function file_put_contents;
+use function sys_get_temp_dir;
+use function tempnam;
+use function unlink;
+
+final class ProfileDictionaryTest extends TestCase
+{
+    public function testJsonDictionaryRecursivelyUsesTitleDocAndDefFallbacks(): void
+    {
+        $profile = <<<'JSON'
+{
+  "alps": {
+    "descriptor": [
+      {"id": "titleFirst", "title": "Title wins", "doc": {"value": "Doc loses"}, "def": "https://schema.org/name"},
+      {"id": "docSecond", "doc": {"value": "Doc fallback"}, "def": "https://schema.org/description"},
+      {"id": "stringDoc", "doc": "String doc fallback"},
+      {"id": "defThird", "def": "https://schema.org/identifier"},
+      {"id": "empty"},
+      {"id": "Parent", "descriptor": [
+        {"id": "nested", "title": "Nested title"}
+      ]}
+    ]
+  }
+}
+JSON;
+        $file = $this->writeTempFile($profile, '.json');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArray();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('Title wins', $dictionary['titleFirst']);
+        $this->assertSame('Doc fallback', $dictionary['docSecond']);
+        $this->assertSame('String doc fallback', $dictionary['stringDoc']);
+        $this->assertSame('[https://schema.org/identifier](https://schema.org/identifier)', $dictionary['defThird']);
+        $this->assertSame('', $dictionary['empty']);
+        $this->assertSame('Nested title', $dictionary['nested']);
+    }
+
+    public function testXmlDictionaryRecursivelyUsesTitleDocAndDefFallbacks(): void
+    {
+        $profile = <<<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<alps version="1.0">
+  <descriptor id="titleFirst" title="Title wins" def="https://schema.org/name">
+    <doc>Doc loses</doc>
+  </descriptor>
+  <descriptor id="docSecond" def="https://schema.org/description">
+    <doc>Doc fallback</doc>
+  </descriptor>
+  <descriptor id="docAttribute">
+    <doc value="Attribute doc fallback"/>
+  </descriptor>
+  <descriptor id="defThird" def="https://schema.org/identifier"/>
+  <descriptor id="empty"/>
+  <descriptor id="Parent">
+    <descriptor id="nested" title="Nested title"/>
+  </descriptor>
+</alps>
+XML;
+        $file = $this->writeTempFile($profile, '.xml');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArray();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('Title wins', $dictionary['titleFirst']);
+        $this->assertSame('Doc fallback', $dictionary['docSecond']);
+        $this->assertSame('Attribute doc fallback', $dictionary['docAttribute']);
+        $this->assertSame('[https://schema.org/identifier](https://schema.org/identifier)', $dictionary['defThird']);
+        $this->assertSame('', $dictionary['empty']);
+        $this->assertSame('Nested title', $dictionary['nested']);
+    }
+
+    public function testArrayObjectKeepsExistingApiDocDictionaryShape(): void
+    {
+        $file = $this->writeTempFile('{"alps":{"descriptor":[{"id":"firstName","title":"First Name"}]}}', '.json');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArrayObject();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('First Name', $dictionary['firstName']);
+    }
+
+    private function writeTempFile(string $contents, string $extension): string
+    {
+        $baseFile = tempnam(sys_get_temp_dir(), 'bear-apidoc-alps-profile-');
+        assert($baseFile !== false);
+        $file = $baseFile . $extension;
+        @unlink($baseFile);
+        file_put_contents($file, $contents);
+
+        return $file;
+    }
+}

--- a/tests/ProfileDictionaryTest.php
+++ b/tests/ProfileDictionaryTest.php
@@ -183,6 +183,53 @@ JSON;
         $this->assertSame('City name', $dictionary['city']);
     }
 
+    public function testResolvesExternalXmlHrefAndRtReferences(): void
+    {
+        $external = $this->writeTempFile(
+            '<?xml version="1.0"?><alps version="1.0">'
+            . '<descriptor id="sharedName" title="Shared from external XML"/>'
+            . '<descriptor id="SharedState" title="Shared XML state"/>'
+            . '</alps>',
+            '.xml',
+        );
+        $main = $this->writeTempFile(
+            sprintf(
+                '<?xml version="1.0"?><alps version="1.0">'
+                . '<descriptor href="%1$s#sharedName"/>'
+                . '<descriptor id="goShared" type="safe" rt="%1$s#SharedState" title="Go shared"/>'
+                . '</alps>',
+                basename($external),
+            ),
+            '.xml',
+        );
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($main)->toArray();
+        } finally {
+            @unlink($main);
+            @unlink($external);
+        }
+
+        $this->assertSame('Shared from external XML', $dictionary['sharedName']);
+        $this->assertSame('Go shared', $dictionary['goShared']);
+        $this->assertSame('Shared XML state', $dictionary['SharedState']);
+    }
+
+    public function testRemoteHrefReferenceIsNotFetched(): void
+    {
+        $profile = '{"alps":{"descriptor":[{"id":"local","title":"Local"},{"href":"https://example.com/common.json#remote"}]}}';
+        $file = $this->writeTempFile($profile, '.json');
+
+        try {
+            $dictionary = ProfileDictionary::fromFile($file)->toArray();
+        } finally {
+            @unlink($file);
+        }
+
+        $this->assertSame('Local', $dictionary['local']);
+        $this->assertArrayNotHasKey('remote', $dictionary);
+    }
+
     public function testFromFileTreatsNonXmlExtensionAsJson(): void
     {
         $file = $this->writeTempFile('{"alps":{"descriptor":[{"id":"upper","title":"Upper JSON"}]}}', '.JSON');


### PR DESCRIPTION
## Summary

- remove the `koriym/app-state-diagram` runtime dependency from BEAR.ApiDoc
- add a small internal ALPS profile dictionary reader under `src-alps/`
- keep the existing `ArrayObject<string, string>` dictionary surface used by HTML/Markdown documentation generation
- cover JSON and XML ALPS descriptors, including nested descriptors and title/doc/def fallback behavior

## Rationale

`app-state-diagram` is now maintained as a JavaScript ASD package for diagram rendering. BEAR.ApiDoc only needs the ALPS profile label dictionary for generated documentation, so this keeps the PHP side focused on profile reading and avoids depending on the old PHP diagram package.

## Validation

- `zsh -ic 'sphp85; vendor/bin/phpunit tests/ProfileDictionaryTest.php tests/ApiDocTest.php --filter "ProfileDictionary|Alps"'`
- `zsh -ic 'sphp85; composer cs'`
- `zsh -ic 'sphp85; composer sa'`
- `zsh -ic 'sphp85; composer test'`
- `git diff --check`
- `rg -n "Koriym\\\\AppStateDiagram|app-state-diagram|koriym/app-state-diagram" src src-alps tests composer.json`
- `zsh -ic 'sphp85; composer why koriym/app-state-diagram --locked'` reports the package is not present
